### PR TITLE
Compatible sqlserver2008

### DIFF
--- a/src/DotNetCore.CAP.SqlServer/CAP.EFOptions.cs
+++ b/src/DotNetCore.CAP.SqlServer/CAP.EFOptions.cs
@@ -20,5 +20,13 @@ namespace DotNetCore.CAP
         /// EF dbcontext type.
         /// </summary>
         internal Type DbContextType { get; set; }
+
+        internal bool IsSqlServer2008 { get; set; }
+
+        public EFOptions UseSqlServer2008()
+        {
+            IsSqlServer2008 = true;
+            return this;
+        }
     }
 }

--- a/src/DotNetCore.CAP.SqlServer/CAP.SqlServerOptions.cs
+++ b/src/DotNetCore.CAP.SqlServer/CAP.SqlServerOptions.cs
@@ -9,5 +9,13 @@ namespace DotNetCore.CAP
         /// Gets or sets the database's connection string that will be used to store database entities.
         /// </summary>
         public string ConnectionString { get; set; }
+
+        internal bool IsSqlServer2008 { get; set; }
+
+        public SqlServerOptions UseSqlServer2008()
+        {
+            IsSqlServer2008 = true;
+            return this;
+        }
     }
 }

--- a/src/DotNetCore.CAP.SqlServer/CAP.SqlServerOptions.cs
+++ b/src/DotNetCore.CAP.SqlServer/CAP.SqlServerOptions.cs
@@ -9,13 +9,5 @@ namespace DotNetCore.CAP
         /// Gets or sets the database's connection string that will be used to store database entities.
         /// </summary>
         public string ConnectionString { get; set; }
-
-        internal bool IsSqlServer2008 { get; set; }
-
-        public SqlServerOptions UseSqlServer2008()
-        {
-            IsSqlServer2008 = true;
-            return this;
-        }
     }
 }

--- a/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
@@ -89,14 +89,19 @@ select count(Id) from [{0}].Received with (nolock) where StatusName = N'Failed';
                 where += " and content like '%@Content%'";
             }
 
-            var sqlQuery =
+            var sqlQuery2008 =
                 $@"select * from 
                 (SELECT t.*, ROW_NUMBER() OVER(order by t.Added desc) AS rownumber
                     from [{_options.Schema}].{tableName} as t
                     where 1=1 {where}) as tbl
                 where tbl.rownumber between @offset and @offset + @limit";
 
-            return UseConnection(conn => conn.Query<MessageDto>(sqlQuery, new
+            var sqlQuery =
+                $"select * from [{_options.Schema}].{tableName} where 1=1 {where} order by Added desc offset @Offset rows fetch next @Limit rows only";
+
+
+
+            return UseConnection(conn => conn.Query<MessageDto>(_options.IsSqlServer2008 ? sqlQuery2008 : sqlQuery, new
             {
                 queryDto.StatusName,
                 queryDto.Group,
@@ -163,9 +168,7 @@ select count(Id) from [{0}].Received with (nolock) where StatusName = N'Failed';
             string statusName,
             IDictionary<string, DateTime> keyMaps)
         {
-            //SQL Server 2012+ 
-            var sqlQuery =
-                $@"
+            var sqlQuery2008 = $@"
 with aggr as (
     select replace(convert(varchar, Added, 111), '/','-') + '-' + CONVERT(varchar, DATEPART(hh, Added)) as [Key],
         count(id) [Count]
@@ -175,8 +178,19 @@ with aggr as (
 )
 select [Key], [Count] from aggr with (nolock) where [Key] in @keys;";
 
+            //SQL Server 2012+ 
+            var sqlQuery = $@"
+with aggr as (
+    select FORMAT(Added,'yyyy-MM-dd-HH') as [Key],
+        count(id) [Count]
+    from  [{_options.Schema}].{tableName}
+    where StatusName = @statusName
+    group by FORMAT(Added,'yyyy-MM-dd-HH')
+)
+select [Key], [Count] from aggr with (nolock) where [Key] in @keys;";
+
             var valuesMap = connection.Query<TimelineCounter>(
-                    sqlQuery,
+                    _options.IsSqlServer2008 ? sqlQuery2008 : sqlQuery,
                     new { keys = keyMaps.Keys, statusName })
                 .ToDictionary(x => x.Key, x => x.Count);
 

--- a/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
@@ -99,8 +99,6 @@ select count(Id) from [{0}].Received with (nolock) where StatusName = N'Failed';
             var sqlQuery =
                 $"select * from [{_options.Schema}].{tableName} where 1=1 {where} order by Added desc offset @Offset rows fetch next @Limit rows only";
 
-
-
             return UseConnection(conn => conn.Query<MessageDto>(_options.IsSqlServer2008 ? sqlQuery2008 : sqlQuery, new
             {
                 queryDto.StatusName,

--- a/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/DotNetCore.CAP.SqlServer/SqlServerMonitoringApi.cs
@@ -159,15 +159,15 @@ select count(Id) from [{0}].Received with (nolock) where StatusName = N'Failed';
             string statusName,
             IDictionary<string, DateTime> keyMaps)
         {
-            //SQL Server 2012+
+            //SQL Server 2012+ 
             var sqlQuery =
                 $@"
 with aggr as (
-    select FORMAT(Added,'yyyy-MM-dd-HH') as [Key],
+    select replace(convert(varchar, Added, 111), '/','-') + '-' + CONVERT(varchar, DATEPART(hh, Added)) as [Key],
         count(id) [Count]
     from  [{_options.Schema}].{tableName}
     where StatusName = @statusName
-    group by FORMAT(Added,'yyyy-MM-dd-HH')
+    group by replace(convert(varchar, Added, 111), '/','-') + '-' + CONVERT(varchar, DATEPART(hh, Added))
 )
 select [Key], [Count] from aggr with (nolock) where [Key] in @keys;";
 


### PR DESCRIPTION
Our SqlServer is still 2008 but wasn't supported by CAP. I do see that SqlServer2008 is too old, but upgrading db is too hard to complete. However, it's easy to be compatible with SqlServer2008.
Usage:
`options.UseEntityFramework<MessageContext>(x =>
                {
                    x.UseSqlServer2008();
                });`
or `options.UseSqlServer(x =>
                {
                    x.UseSqlServer2008();
                });`

And will not affect others who uses SqlServer2012.