### PR TITLE
Abstract MongoTransaction to make the usage more comfortable

### DIFF
--- a/src/DotNetCore.CAP.MongoDB/CAP.MongoDBCapOptionsExtension.cs
+++ b/src/DotNetCore.CAP.MongoDB/CAP.MongoDBCapOptionsExtension.cs
@@ -1,5 +1,6 @@
 using System;
 using DotNetCore.CAP;
+using DotNetCore.CAP.Abstractions;
 using DotNetCore.CAP.Processor;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +23,8 @@ namespace DotNetCore.CAP.MongoDB
             services.AddScoped<ICapPublisher, CapPublisher>();
             services.AddScoped<ICallbackPublisher, CapPublisher>();
             services.AddTransient<ICollectProcessor, MongoDBCollectProcessor>();
+
+            services.AddTransient<IMongoTransaction, MongoTransaction>();
 
             var options = new MongoDBOptions();
             _configure?.Invoke(options);

--- a/src/DotNetCore.CAP.MongoDB/CapPublisher.cs
+++ b/src/DotNetCore.CAP.MongoDB/CapPublisher.cs
@@ -76,7 +76,7 @@ namespace DotNetCore.CAP.MongoDB
                 mongoTransaction = new NullMongoTransaction();
             }
 
-            await PublishWithSessionAsync<T>(name, contentObj, mongoTransaction, callbackName);
+            await PublishWithTransactionAsync<T>(name, contentObj, mongoTransaction, callbackName);
         }
 
         private void PublishWithTransaction<T>(string name, T contentObj, IMongoTransaction transaction, string callbackName)
@@ -137,7 +137,8 @@ namespace DotNetCore.CAP.MongoDB
             return message.Id;
         }
 
-        private async Task PublishWithSessionAsync<T>(string name, T contentObj, IMongoTransaction transaction, string callbackName)
+
+        private async Task PublishWithTransactionAsync<T>(string name, T contentObj, IMongoTransaction transaction, string callbackName)
         {
             var operationId = default(Guid);
             var content = Serialize(contentObj, callbackName);

--- a/src/DotNetCore.CAP.MongoDB/MongoTransaction.cs
+++ b/src/DotNetCore.CAP.MongoDB/MongoTransaction.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using DotNetCore.CAP.Abstractions;
+using MongoDB.Driver;
+
+namespace DotNetCore.CAP.MongoDB
+{
+    public class MongoTransaction : IMongoTransaction
+    {
+        private readonly IMongoClient _client;
+        public MongoTransaction(IMongoClient client)
+        {
+            _client = client;
+        }
+
+        public IClientSessionHandle Session { get; set; }
+        public bool AutoCommit { get; set; }
+
+        public async Task<IMongoTransaction> BegeinAsync(bool autoCommit = true)
+        {
+            AutoCommit = autoCommit;
+            Session = await _client.StartSessionAsync();
+            Session.StartTransaction();
+            return this;
+        }
+
+        public IMongoTransaction Begein(bool autoCommit = true)
+        {
+            AutoCommit = autoCommit;
+            Session = _client.StartSession();
+            Session.StartTransaction();
+            return this;
+        }
+
+        public void Dispose()
+        {
+            Session?.Dispose();
+        }
+    }
+
+    public class NullMongoTransaction : MongoTransaction
+    {
+        public NullMongoTransaction(IMongoClient client = null) : base(client)
+        {
+            AutoCommit = false;
+        }
+    }
+
+    public static class MongoTransactionExtensions
+    {
+        public static IClientSessionHandle GetSession(this IMongoTransaction mongoTransaction)
+        {
+            var trans = mongoTransaction as MongoTransaction;
+            return trans?.Session;
+        }
+    }
+}

--- a/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
+++ b/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
@@ -67,12 +67,12 @@ namespace DotNetCore.CAP.Abstractions
             return PublishWithTransAsync(name, contentObj, callbackName);
         }
 
-        public virtual void PublishWithMongo<T>(string name, T contentObj, object mongoSession = null, string callbackName = null)
+        public virtual void PublishWithMongo<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null)
         {
             throw new NotImplementedException("Work for MongoDB only.");
         }
 
-        public virtual Task PublishWithMongoAsync<T>(string name, T contentObj, object mongoSession = null, string callbackName = null)
+        public virtual Task PublishWithMongoAsync<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null)
         {
             throw new NotImplementedException("Work for MongoDB only.");
         }

--- a/src/DotNetCore.CAP/Abstractions/IMongoTransaction.cs
+++ b/src/DotNetCore.CAP/Abstractions/IMongoTransaction.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DotNetCore.CAP.Abstractions
+{
+    public interface IMongoTransaction : IDisposable
+    {
+        /// <summary>
+        /// If set true, the session.CommitTransaction() will be called automatically.
+        /// </summary>
+        /// <value></value>
+        bool AutoCommit { get; set; }
+
+        Task<IMongoTransaction> BegeinAsync(bool autoCommit = true);
+        
+        IMongoTransaction Begein(bool autoCommit = true);
+    }
+}

--- a/src/DotNetCore.CAP/ICapPublisher.cs
+++ b/src/DotNetCore.CAP/ICapPublisher.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using System.Threading.Tasks;
+using DotNetCore.CAP.Abstractions;
 
 namespace DotNetCore.CAP
 {
@@ -60,17 +61,17 @@ namespace DotNetCore.CAP
         /// </summary>
         /// <param name="name">the topic name or exchange router key.</param>
         /// <param name="contentObj">message body content, that will be serialized of json.</param>
-        /// <param name="mongoSession">if seesion was set null, the message will be published directly.</param>
+        /// <param name="mongoTransaction">if transaction was set null, the message will be published directly.</param>
         /// <param name="callbackName">callback subscriber name</param>
-        void PublishWithMongo<T>(string name, T contentObj, object mongoSession = null, string callbackName = null);
+        void PublishWithMongo<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null);
 
         /// <summary>
         ///  Asynchronous publish an object message with mongo.
         /// </summary>
         /// <param name="name">the topic name or exchange router key.</param>
         /// <param name="contentObj">message body content, that will be serialized of json.</param>
-        /// <param name="mongoSession">if seesion was set null, the message will be published directly.</param>
+        /// <param name="mongoTransaction">if transaction was set null, the message will be published directly.</param>
         /// <param name="callbackName">callback subscriber name</param>
-        Task PublishWithMongoAsync<T>(string name, T contentObj, object mongoSession = null, string callbackName = null);
+        Task PublishWithMongoAsync<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null);
     }
 }

--- a/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
+++ b/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
@@ -169,12 +169,12 @@ namespace DotNetCore.CAP.Test
                 throw new NotImplementedException();
             }
 
-            public void PublishWithMongo<T>(string name, T contentObj, object mongoSession = null, string callbackName = null)
+            public void PublishWithMongo<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task PublishWithMongoAsync<T>(string name, T contentObj, object mongoSession = null, string callbackName = null)
+            public Task PublishWithMongoAsync<T>(string name, T contentObj, IMongoTransaction mongoTransaction = null, string callbackName = null)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Improve the usage like this:
```c#
using (var trans = await _mongoTransaction.BegeinAsync())
{
    repository.InsertOne(trans.GetSession(), someValue);
    await _capPublisher.PublishWithMongoAsync("sample.rabbitmq.mongodb", DateTime.Now, trans);
}
```