### PR TITLE
Fix that Version doesn't match

### DIFF
--- a/src/DotNetCore.CAP.MongoDB/ICollectProcessor.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/ICollectProcessor.MongoDB.cs
@@ -31,18 +31,18 @@ namespace DotNetCore.CAP.MongoDB
             _logger.LogDebug(
                 $"Collecting expired data from collection [{_options.PublishedCollection}].");
 
-            var publishedCollection = _database.GetCollection<CapPublishedMessage>(_options.PublishedCollection);
-            var receivedCollection = _database.GetCollection<CapReceivedMessage>(_options.ReceivedCollection);
+            var publishedCollection = _database.GetCollection<PublishedMessage>(_options.PublishedCollection);
+            var receivedCollection = _database.GetCollection<ReceivedMessage>(_options.ReceivedCollection);
 
             await publishedCollection.BulkWriteAsync(new[]
             {
-                new DeleteManyModel<CapPublishedMessage>(
-                    Builders<CapPublishedMessage>.Filter.Lt(x => x.ExpiresAt, DateTime.Now))
+                new DeleteManyModel<PublishedMessage>(
+                    Builders<PublishedMessage>.Filter.Lt(x => x.ExpiresAt, DateTime.Now))
             });
             await receivedCollection.BulkWriteAsync(new[]
             {
-                new DeleteManyModel<CapReceivedMessage>(
-                    Builders<CapReceivedMessage>.Filter.Lt(x => x.ExpiresAt, DateTime.Now))
+                new DeleteManyModel<ReceivedMessage>(
+                    Builders<ReceivedMessage>.Filter.Lt(x => x.ExpiresAt, DateTime.Now))
             });
 
             await context.WaitAsync(_waitingInterval);

--- a/src/DotNetCore.CAP.MongoDB/IStorageTransaction.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorageTransaction.MongoDB.cs
@@ -39,9 +39,9 @@ namespace DotNetCore.CAP.MongoDB
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var collection = _database.GetCollection<CapPublishedMessage>(_options.PublishedCollection);
+            var collection = _database.GetCollection<PublishedMessage>(_options.PublishedCollection);
 
-            var updateDef = Builders<CapPublishedMessage>.Update
+            var updateDef = Builders<PublishedMessage>.Update
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.Content, message.Content)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)
@@ -57,9 +57,9 @@ namespace DotNetCore.CAP.MongoDB
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var collection = _database.GetCollection<CapReceivedMessage>(_options.ReceivedCollection);
+            var collection = _database.GetCollection<ReceivedMessage>(_options.ReceivedCollection);
 
-            var updateDef = Builders<CapReceivedMessage>.Update
+            var updateDef = Builders<ReceivedMessage>.Update
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.Content, message.Content)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)


### PR DESCRIPTION
After `DotNetCore.CAP.MongoDB` updated to 2.4, there was a bug. This PR fixed that.
```
[Error] An exception occurred while executing the subscription method. Topic:Feed.Created, Id:1075252961419243520
System.FormatException: Element 'Version' does not match any field or property of class DotNetCore.CAP.Models.CapReceivedMessage.
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.DeserializeClass(BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.ElementDeserializer`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.FindAndModifyValueDeserializer`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.FindAndModifyOperationBase`1.ProcessCommandResult(ConnectionId connectionId, RawBsonDocument rawBsonDocument)
   at MongoDB.Driver.Core.Operations.FindAndModifyOperationBase`1.ExecuteAttempt(RetryableWriteContext context, Int32 attempt, Nullable`1 transactionNumber, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.RetryableWriteOperationExecutor.Execute[TResult](IRetryableWriteOperation`1 operation, RetryableWriteContext context, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.RetryableWriteOperationExecutor.Execute[TResult](IRetryableWriteOperation`1 operation, IWriteBinding binding, Boolean retryRequested, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.FindAndModifyOperationBase`1.Execute(IWriteBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.OperationExecutor.ExecuteWriteOperation[TResult](IWriteBinding binding, IWriteOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteWriteOperation[TResult](IClientSessionHandle session, IWriteOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.FindOneAndUpdate[TProjection](IClientSessionHandle session, FilterDefinition`1 filter, UpdateDefinition`1 update, FindOneAndUpdateOptions`2 options, CancellationToken cancellationToken)
   at MongoDB.Driver.IMongoCollectionExtensions.FindOneAndUpdate[TDocument](IMongoCollection`1 collection, IClientSessionHandle session, Expression`1 filter, UpdateDefinition`1 update, FindOneAndUpdateOptions`2 options, CancellationToken cancellationToken)
   at DotNetCore.CAP.MongoDB.MongoDBStorageTransaction.UpdateMessage(CapReceivedMessage message)
   at DotNetCore.CAP.Processor.States.StateChanger.ChangeState(CapReceivedMessage message, IState state, IStorageTransaction transaction)
   at DotNetCore.CAP.Processor.States.StateChangerExtensions.ChangeStateAsync(IStateChanger this, CapReceivedMessage message, IState state, IStorageConnection connection)
   at DotNetCore.CAP.DefaultSubscriberExecutor.ExecuteWithoutRetryAsync(CapReceivedMessage message)
```