### PR TITLE
Add ConsumerCount for Dispatcher

### DIFF
--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -8,89 +8,99 @@ using DotNetCore.CAP.Models;
 
 namespace DotNetCore.CAP
 {
-    /// <summary>
-    /// Represents all the options you can use to configure the system.
-    /// </summary>
-    public class CapOptions
-    {
-        /// <summary>
-        /// Default succeeded message expiration time span, in seconds.
-        /// </summary>
-        public const int DefaultSucceedMessageExpirationAfter = 24 * 3600;
+	/// <summary>
+	/// Represents all the options you can use to configure the system.
+	/// </summary>
+	public class CapOptions
+	{
+		/// <summary>
+		/// Default succeeded message expiration time span, in seconds.
+		/// </summary>
+		public const int DefaultSucceedMessageExpirationAfter = 24 * 3600;
 
-        /// <summary>
-        /// Failed message retry waiting interval.
-        /// </summary>
-        public const int DefaultFailedMessageWaitingInterval = 60;
+		/// <summary>
+		/// Failed message retry waiting interval.
+		/// </summary>
+		public const int DefaultFailedMessageWaitingInterval = 60;
 
-        /// <summary>
-        /// Failed message retry count.
-        /// </summary>
-        public const int DefaultFailedRetryCount = 50;
+		/// <summary>
+		/// Failed message retry count.
+		/// </summary>
+		public const int DefaultFailedRetryCount = 50;
 
-        /// <summary>
-        /// Default version
-        /// </summary>
-        public const string DefaultVersion = "v1";
+		/// <summary>
+		/// Default version
+		/// </summary>
+		public const string DefaultVersion = "v1";
+
+		/// <summary>
+		/// Default Consumer Count
+		/// </summary>
+		public const int DefaultConsumerCount = 1;
 
 
-        public CapOptions()
-        {
-            SucceedMessageExpiredAfter = DefaultSucceedMessageExpirationAfter;
-            FailedRetryInterval = DefaultFailedMessageWaitingInterval;
-            FailedRetryCount = DefaultFailedRetryCount;
-            Extensions = new List<ICapOptionsExtension>();
-            Version = DefaultVersion;
-            DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly().GetName().Name.ToLower();
-        }
 
-        internal IList<ICapOptionsExtension> Extensions { get; }
+		public CapOptions()
+		{
+			SucceedMessageExpiredAfter = DefaultSucceedMessageExpirationAfter;
+			FailedRetryInterval = DefaultFailedMessageWaitingInterval;
+			FailedRetryCount = DefaultFailedRetryCount;
+			Extensions = new List<ICapOptionsExtension>();
+			Version = DefaultVersion;
+			DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly().GetName().Name.ToLower();
+			ConsumerCount = DefaultConsumerCount;
+		}
 
-        /// <summary>
-        /// Subscriber default group name. kafka-->group name. rabbitmq --> queue name.
-        /// </summary>
-        public string DefaultGroup { get; set; }
+		internal IList<ICapOptionsExtension> Extensions { get; }
 
-        /// <summary>
-        /// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20
-        /// </summary>
-        public string Version { get; set; }
+		/// <summary>
+		/// Subscriber default group name. kafka-->group name. rabbitmq --> queue name.
+		/// </summary>
+		public string DefaultGroup { get; set; }
 
-        /// <summary>
-        /// Sent or received succeed message after time span of due, then the message will be deleted at due time.
-        /// Default is 24*3600 seconds.
-        /// </summary>
-        public int SucceedMessageExpiredAfter { get; set; }
+		/// <summary>
+		/// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20
+		/// </summary>
+		public string Version { get; set; }
 
-        /// <summary>
-        /// Failed messages polling delay time.
-        /// Default is 60 seconds.
-        /// </summary>
-        public int FailedRetryInterval { get; set; }
+		/// <summary>
+		/// Sent or received succeed message after time span of due, then the message will be deleted at due time.
+		/// Default is 24*3600 seconds.
+		/// </summary>
+		public int SucceedMessageExpiredAfter { get; set; }
 
-        /// <summary>
-        /// We’ll invoke this call-back with message type,name,content when retry failed (send or executed) messages equals <see cref="FailedRetryCount"/> times.
-        /// </summary>
-        public Action<MessageType, string, string> FailedThresholdCallback { get; set; }
+		/// <summary>
+		/// Failed messages polling delay time.
+		/// Default is 60 seconds.
+		/// </summary>
+		public int FailedRetryInterval { get; set; }
 
-        /// <summary>
-        /// The number of message retries, the retry will stop when the threshold is reached.
-        /// Default is 50 times.
-        /// </summary>
-        public int FailedRetryCount { get; set; }
+		/// <summary>
+		/// We’ll invoke this call-back with message type,name,content when retry failed (send or executed) messages equals <see cref="FailedRetryCount"/> times.
+		/// </summary>
+		public Action<MessageType, string, string> FailedThresholdCallback { get; set; }
 
-        /// <summary>
-        /// Registers an extension that will be executed when building services.
-        /// </summary>
-        /// <param name="extension"></param>
-        public void RegisterExtension(ICapOptionsExtension extension)
-        {
-            if (extension == null)
-            {
-                throw new ArgumentNullException(nameof(extension));
-            }
+		/// <summary>
+		/// The number of message retries, the retry will stop when the threshold is reached.
+		/// Default is 50 times.
+		/// </summary>
+		public int FailedRetryCount { get; set; }
 
-            Extensions.Add(extension);
-        }
-    }
+		/// <summary>
+		/// Registers an extension that will be executed when building services.
+		/// </summary>
+		/// <param name="extension"></param>
+		public void RegisterExtension(ICapOptionsExtension extension)
+		{
+			if (extension == null)
+			{
+				throw new ArgumentNullException(nameof(extension));
+			}
+
+			Extensions.Add(extension);
+		}
+
+		public int ConsumerCount { get; set; }
+
+	}
 }

--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -8,99 +8,99 @@ using DotNetCore.CAP.Models;
 
 namespace DotNetCore.CAP
 {
-	/// <summary>
-	/// Represents all the options you can use to configure the system.
-	/// </summary>
-	public class CapOptions
-	{
-		/// <summary>
-		/// Default succeeded message expiration time span, in seconds.
-		/// </summary>
-		public const int DefaultSucceedMessageExpirationAfter = 24 * 3600;
+    /// <summary>
+    /// Represents all the options you can use to configure the system.
+    /// </summary>
+    public class CapOptions
+    {
+        /// <summary>
+        /// Default succeeded message expiration time span, in seconds.
+        /// </summary>
+        public const int DefaultSucceedMessageExpirationAfter = 24 * 3600;
 
-		/// <summary>
-		/// Failed message retry waiting interval.
-		/// </summary>
-		public const int DefaultFailedMessageWaitingInterval = 60;
+        /// <summary>
+        /// Failed message retry waiting interval.
+        /// </summary>
+        public const int DefaultFailedMessageWaitingInterval = 60;
 
-		/// <summary>
-		/// Failed message retry count.
-		/// </summary>
-		public const int DefaultFailedRetryCount = 50;
+        /// <summary>
+        /// Failed message retry count.
+        /// </summary>
+        public const int DefaultFailedRetryCount = 50;
 
-		/// <summary>
-		/// Default version
-		/// </summary>
-		public const string DefaultVersion = "v1";
+        /// <summary>
+        /// Default version
+        /// </summary>
+        public const string DefaultVersion = "v1";
 
-		/// <summary>
-		/// Default Consumer Count
-		/// </summary>
-		public const int DefaultConsumerCount = 1;
+        /// <summary>
+        /// Default Consumer Count
+        /// </summary>
+        public const int DefaultConsumerCount = 1;
 
 
 
-		public CapOptions()
-		{
-			SucceedMessageExpiredAfter = DefaultSucceedMessageExpirationAfter;
-			FailedRetryInterval = DefaultFailedMessageWaitingInterval;
-			FailedRetryCount = DefaultFailedRetryCount;
-			Extensions = new List<ICapOptionsExtension>();
-			Version = DefaultVersion;
-			DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly().GetName().Name.ToLower();
-			ConsumerCount = DefaultConsumerCount;
-		}
+        public CapOptions()
+        {
+            SucceedMessageExpiredAfter = DefaultSucceedMessageExpirationAfter;
+            FailedRetryInterval = DefaultFailedMessageWaitingInterval;
+            FailedRetryCount = DefaultFailedRetryCount;
+            Extensions = new List<ICapOptionsExtension>();
+            Version = DefaultVersion;
+            DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly().GetName().Name.ToLower();
+            ConsumerCount = DefaultConsumerCount;
+        }
 
-		internal IList<ICapOptionsExtension> Extensions { get; }
+        internal IList<ICapOptionsExtension> Extensions { get; }
 
-		/// <summary>
-		/// Subscriber default group name. kafka-->group name. rabbitmq --> queue name.
-		/// </summary>
-		public string DefaultGroup { get; set; }
+        /// <summary>
+        /// Subscriber default group name. kafka-->group name. rabbitmq --> queue name.
+        /// </summary>
+        public string DefaultGroup { get; set; }
 
-		/// <summary>
-		/// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20
-		/// </summary>
-		public string Version { get; set; }
+        /// <summary>
+        /// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20
+        /// </summary>
+        public string Version { get; set; }
 
-		/// <summary>
-		/// Sent or received succeed message after time span of due, then the message will be deleted at due time.
-		/// Default is 24*3600 seconds.
-		/// </summary>
-		public int SucceedMessageExpiredAfter { get; set; }
+        /// <summary>
+        /// Sent or received succeed message after time span of due, then the message will be deleted at due time.
+        /// Default is 24*3600 seconds.
+        /// </summary>
+        public int SucceedMessageExpiredAfter { get; set; }
 
-		/// <summary>
-		/// Failed messages polling delay time.
-		/// Default is 60 seconds.
-		/// </summary>
-		public int FailedRetryInterval { get; set; }
+        /// <summary>
+        /// Failed messages polling delay time.
+        /// Default is 60 seconds.
+        /// </summary>
+        public int FailedRetryInterval { get; set; }
 
-		/// <summary>
-		/// We’ll invoke this call-back with message type,name,content when retry failed (send or executed) messages equals <see cref="FailedRetryCount"/> times.
-		/// </summary>
-		public Action<MessageType, string, string> FailedThresholdCallback { get; set; }
+        /// <summary>
+        /// We’ll invoke this call-back with message type,name,content when retry failed (send or executed) messages equals <see cref="FailedRetryCount"/> times.
+        /// </summary>
+        public Action<MessageType, string, string> FailedThresholdCallback { get; set; }
 
-		/// <summary>
-		/// The number of message retries, the retry will stop when the threshold is reached.
-		/// Default is 50 times.
-		/// </summary>
-		public int FailedRetryCount { get; set; }
+        /// <summary>
+        /// The number of message retries, the retry will stop when the threshold is reached.
+        /// Default is 50 times.
+        /// </summary>
+        public int FailedRetryCount { get; set; }
 
-		/// <summary>
-		/// Registers an extension that will be executed when building services.
-		/// </summary>
-		/// <param name="extension"></param>
-		public void RegisterExtension(ICapOptionsExtension extension)
-		{
-			if (extension == null)
-			{
-				throw new ArgumentNullException(nameof(extension));
-			}
+        /// <summary>
+        /// Registers an extension that will be executed when building services.
+        /// </summary>
+        /// <param name="extension"></param>
+        public void RegisterExtension(ICapOptionsExtension extension)
+        {
+            if (extension == null)
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
 
-			Extensions.Add(extension);
-		}
+            Extensions.Add(extension);
+        }
 
-		public int ConsumerCount { get; set; }
+        public int ConsumerCount { get; set; }
 
-	}
+    }
 }

--- a/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
@@ -11,110 +11,110 @@ using System.Linq;
 
 namespace DotNetCore.CAP.Processor
 {
-	public class Dispatcher : IDispatcher, IDisposable
-	{
-		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-		private readonly ISubscriberExecutor _executor;
-		private readonly ILogger<Dispatcher> _logger;
-		private readonly CapOptions _capOptions;
+    public class Dispatcher : IDispatcher, IDisposable
+    {
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly ISubscriberExecutor _executor;
+        private readonly ILogger<Dispatcher> _logger;
+        private readonly CapOptions _capOptions;
 
-		private readonly BlockingCollection<CapPublishedMessage> _publishedMessageQueue =
-			new BlockingCollection<CapPublishedMessage>(new ConcurrentQueue<CapPublishedMessage>());
+        private readonly BlockingCollection<CapPublishedMessage> _publishedMessageQueue =
+            new BlockingCollection<CapPublishedMessage>(new ConcurrentQueue<CapPublishedMessage>());
 
-		private readonly BlockingCollection<CapReceivedMessage> _receivedMessageQueue =
-			new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
+        private readonly BlockingCollection<CapReceivedMessage> _receivedMessageQueue =
+            new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
 
-		private readonly ConcurrentBag<BlockingCollection<CapReceivedMessage>> _receivedMessageQueueList =
-		   new ConcurrentBag<BlockingCollection<CapReceivedMessage>>();
+        private readonly ConcurrentBag<BlockingCollection<CapReceivedMessage>> _receivedMessageQueueList =
+           new ConcurrentBag<BlockingCollection<CapReceivedMessage>>();
 
-		private readonly IPublishMessageSender _sender;
+        private readonly IPublishMessageSender _sender;
 
-		public Dispatcher(ILogger<Dispatcher> logger,
-			IPublishMessageSender sender,
-			ISubscriberExecutor executor,
-			CapOptions capOptions)
-		{
-			_logger = logger;
-			_sender = sender;
-			_executor = executor;
-			_capOptions = capOptions;
-			for (int i = 1; i <= _capOptions.ConsumerCount; i++)
-			{
-				var receivedMessageQueue = new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
-				_receivedMessageQueueList.Add(receivedMessageQueue);
-				Task.Factory.StartNew(_ => DoProcessing(receivedMessageQueue), receivedMessageQueue);
-			}
-			Task.Factory.StartNew(Sending);
-			//Task.Factory.StartNew(Processing);
-		}
+        public Dispatcher(ILogger<Dispatcher> logger,
+            IPublishMessageSender sender,
+            ISubscriberExecutor executor,
+            CapOptions capOptions)
+        {
+            _logger = logger;
+            _sender = sender;
+            _executor = executor;
+            _capOptions = capOptions;
+            for (int i = 1; i <= _capOptions.ConsumerCount; i++)
+            {
+                var receivedMessageQueue = new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
+                _receivedMessageQueueList.Add(receivedMessageQueue);
+                Task.Factory.StartNew(_ => DoProcessing(receivedMessageQueue), receivedMessageQueue);
+            }
+            Task.Factory.StartNew(Sending);
+            //Task.Factory.StartNew(Processing);
+        }
 
-		public void EnqueueToPublish(CapPublishedMessage message)
-		{
-			_publishedMessageQueue.Add(message);
-		}
+        public void EnqueueToPublish(CapPublishedMessage message)
+        {
+            _publishedMessageQueue.Add(message);
+        }
 
-		public void EnqueueToExecute(CapReceivedMessage message)
-		{
-			int next = new Random().Next(0, _capOptions.ConsumerCount - 1);
-			_receivedMessageQueueList.ToList()[next].Add(message);
-		}
+        public void EnqueueToExecute(CapReceivedMessage message)
+        {
+            int next = new Random().Next(0, _capOptions.ConsumerCount - 1);
+            _receivedMessageQueueList.ToList()[next].Add(message);
+        }
 
-		public void Dispose()
-		{
-			_cts.Cancel();
-		}
+        public void Dispose()
+        {
+            _cts.Cancel();
+        }
 
-		private void Sending()
-		{
-			try
-			{
-				while (!_publishedMessageQueue.IsCompleted)
-				{
-					if (_publishedMessageQueue.TryTake(out var message, 100, _cts.Token))
-					{
-						try
-						{
-							_sender.SendAsync(message);
-						}
-						catch (Exception ex)
-						{
-							_logger.LogError(ex, $"An exception occurred when sending a message to the MQ. Topic:{message.Name}, Id:{message.Id}");
-						}
-					}
-				}
-			}
-			catch (OperationCanceledException)
-			{
-				// expected
-			}
-		}
-		private void DoProcessing(BlockingCollection<CapReceivedMessage> receivedMessageQueue)
-		{
-			try
-			{
-				foreach (var message in receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
-				{
-					_executor.ExecuteAsync(message);
-				}
-			}
-			catch (OperationCanceledException)
-			{
-				// expected
-			}
-		}
-		private void Processing()
-		{
-			try
-			{
-				foreach (var message in _receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
-				{
-					_executor.ExecuteAsync(message);
-				}
-			}
-			catch (OperationCanceledException)
-			{
-				// expected
-			}
-		}
-	}
+        private void Sending()
+        {
+            try
+            {
+                while (!_publishedMessageQueue.IsCompleted)
+                {
+                    if (_publishedMessageQueue.TryTake(out var message, 100, _cts.Token))
+                    {
+                        try
+                        {
+                            _sender.SendAsync(message);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, $"An exception occurred when sending a message to the MQ. Topic:{message.Name}, Id:{message.Id}");
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        }
+        private void DoProcessing(BlockingCollection<CapReceivedMessage> receivedMessageQueue)
+        {
+            try
+            {
+                foreach (var message in receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
+                {
+                    _executor.ExecuteAsync(message);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        }
+        private void Processing()
+        {
+            try
+            {
+                foreach (var message in _receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
+                {
+                    _executor.ExecuteAsync(message);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        }
+    }
 }

--- a/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -7,88 +7,114 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Models;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace DotNetCore.CAP.Processor
 {
-    public class Dispatcher : IDispatcher, IDisposable
-    {
-        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-        private readonly ISubscriberExecutor _executor;
-        private readonly ILogger<Dispatcher> _logger;
+	public class Dispatcher : IDispatcher, IDisposable
+	{
+		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+		private readonly ISubscriberExecutor _executor;
+		private readonly ILogger<Dispatcher> _logger;
+		private readonly CapOptions _capOptions;
 
-        private readonly BlockingCollection<CapPublishedMessage> _publishedMessageQueue =
-            new BlockingCollection<CapPublishedMessage>(new ConcurrentQueue<CapPublishedMessage>());
+		private readonly BlockingCollection<CapPublishedMessage> _publishedMessageQueue =
+			new BlockingCollection<CapPublishedMessage>(new ConcurrentQueue<CapPublishedMessage>());
 
-        private readonly BlockingCollection<CapReceivedMessage> _receivedMessageQueue =
-            new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
+		private readonly BlockingCollection<CapReceivedMessage> _receivedMessageQueue =
+			new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
 
-        private readonly IPublishMessageSender _sender;
+		private readonly ConcurrentBag<BlockingCollection<CapReceivedMessage>> _receivedMessageQueueList =
+		   new ConcurrentBag<BlockingCollection<CapReceivedMessage>>();
 
-        public Dispatcher(ILogger<Dispatcher> logger,
-            IPublishMessageSender sender,
-            ISubscriberExecutor executor)
-        {
-            _logger = logger;
-            _sender = sender;
-            _executor = executor;
+		private readonly IPublishMessageSender _sender;
 
-            Task.Factory.StartNew(Sending);
-            Task.Factory.StartNew(Processing);
-        }
+		public Dispatcher(ILogger<Dispatcher> logger,
+			IPublishMessageSender sender,
+			ISubscriberExecutor executor,
+			CapOptions capOptions)
+		{
+			_logger = logger;
+			_sender = sender;
+			_executor = executor;
+			_capOptions = capOptions;
+			for (int i = 1; i <= _capOptions.ConsumerCount; i++)
+			{
+				var receivedMessageQueue = new BlockingCollection<CapReceivedMessage>(new ConcurrentQueue<CapReceivedMessage>());
+				_receivedMessageQueueList.Add(receivedMessageQueue);
+				Task.Factory.StartNew(_ => DoProcessing(receivedMessageQueue), receivedMessageQueue);
+			}
+			Task.Factory.StartNew(Sending);
+			//Task.Factory.StartNew(Processing);
+		}
 
-        public void EnqueueToPublish(CapPublishedMessage message)
-        {
-            _publishedMessageQueue.Add(message);
-        }
+		public void EnqueueToPublish(CapPublishedMessage message)
+		{
+			_publishedMessageQueue.Add(message);
+		}
 
-        public void EnqueueToExecute(CapReceivedMessage message)
-        {
-            _receivedMessageQueue.Add(message);
-        }
+		public void EnqueueToExecute(CapReceivedMessage message)
+		{
+			int next = new Random().Next(0, _capOptions.ConsumerCount - 1);
+			_receivedMessageQueueList.ToList()[next].Add(message);
+		}
 
-        public void Dispose()
-        {
-            _cts.Cancel();
-        }
+		public void Dispose()
+		{
+			_cts.Cancel();
+		}
 
-        private void Sending()
-        {
-            try
-            {
-                while (!_publishedMessageQueue.IsCompleted)
-                {
-                    if (_publishedMessageQueue.TryTake(out var message, 100, _cts.Token))
-                    {
-                        try
-                        {
-                            _sender.SendAsync(message);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, $"An exception occurred when sending a message to the MQ. Topic:{message.Name}, Id:{message.Id}");
-                        }
-                    }
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // expected
-            }
-        }
-
-        private void Processing()
-        {
-            try
-            {
-                foreach (var message in _receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
-                {
-                    _executor.ExecuteAsync(message);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // expected
-            }
-        }
-    }
+		private void Sending()
+		{
+			try
+			{
+				while (!_publishedMessageQueue.IsCompleted)
+				{
+					if (_publishedMessageQueue.TryTake(out var message, 100, _cts.Token))
+					{
+						try
+						{
+							_sender.SendAsync(message);
+						}
+						catch (Exception ex)
+						{
+							_logger.LogError(ex, $"An exception occurred when sending a message to the MQ. Topic:{message.Name}, Id:{message.Id}");
+						}
+					}
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// expected
+			}
+		}
+		private void DoProcessing(BlockingCollection<CapReceivedMessage> receivedMessageQueue)
+		{
+			try
+			{
+				foreach (var message in receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
+				{
+					_executor.ExecuteAsync(message);
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// expected
+			}
+		}
+		private void Processing()
+		{
+			try
+			{
+				foreach (var message in _receivedMessageQueue.GetConsumingEnumerable(_cts.Token))
+				{
+					_executor.ExecuteAsync(message);
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// expected
+			}
+		}
+	}
 }


### PR DESCRIPTION
首先感谢下，CAP使用起来真是太方便了，在使用的过程中，生产的速度远远大于消费的速度，看了下源码，发现瓶颈在Processing上，于是试着加了ConsumerCount这个配置，BlockingCollection<CapReceivedMessage> 改为ConcurrentBag<BlockingCollection<CapReceivedMessage>>，然后在EnqueueToExecute的时候使用Random 简单的实现平均add到对应的ConcurrentBag的BlockingCollection<CapReceivedMessage>上，根据ConsumerCount开启多个Task处理每个Consumer对应的BlockingCollection<CapReceivedMessage>。
效果很不错，实现很简陋，不知道有没有什么性能或者影响，（测试了几百万条数据的生成和消费，目前未发现问题）还望帮忙看看，如果可以的把这个配置加进去就太好了。
