### PR TITLE
fix NullReferenceException

### DIFF
--- a/src/DotNetCore.CAP/Diagnostics/TracingHeaders.cs
+++ b/src/DotNetCore.CAP/Diagnostics/TracingHeaders.cs
@@ -9,7 +9,7 @@ namespace DotNetCore.CAP.Diagnostics
 {
     public class TracingHeaders : IEnumerable<KeyValuePair<string, string>>
     {
-        private List<KeyValuePair<string, string>> _dataStore;
+        private List<KeyValuePair<string, string>> _dataStore = new List<KeyValuePair<string, string>>();
 
         public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
         {
@@ -23,11 +23,6 @@ namespace DotNetCore.CAP.Diagnostics
 
         public void Add(string name, string value)
         {
-            if (_dataStore == null)
-            {
-                _dataStore = new List<KeyValuePair<string, string>>();
-            }
-
             _dataStore.Add(new KeyValuePair<string, string>(name, value));
         }
 


### PR DESCRIPTION
在启用 CapBeforePublish 后 发送消息时会导致空引用异常

when DiagnosticListener enabled, publish message will cause null reference exception

Call Stack:
TracingHeaders.GetEnumerator
TracingHeaders.IEnumerable.GetEnumerator
ToJObject
Helper.AddTracingHeaderProperty
BasePublishMessageSender.SendWithoutRetryAsync
BasePublishMessageSender.SendAsync
NeedRetryMessageProcessor.ProcessPublishedAsync
NeedRetryMessageProcessor.ProcessAsync
BasePublishMessageSender.SendWithoutRetryAsync
BasePublishMessageSender.SendAsync
