### PR TITLE
Find ICapSubscribe from IServiceCollection.

### DIFF
--- a/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
+++ b/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+
+        /// <summary>
+        /// The IServiceCollection.
+        /// </summary>
+        public static IServiceCollection SERVICES;
+
         /// <summary>
         /// Adds and configures the consistence services for the consistency.
         /// </summary>
@@ -36,8 +42,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddSingleton<CapMarkerService>();
 
-            //Consumer service
-            AddSubscribeServices(services);
+            //Save IServiceCollection
+            SERVICES = services;
 
             //Serializer and model binder
             services.TryAddSingleton<IContentSerializer, JsonContentSerializer>();
@@ -79,25 +85,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IStartupFilter, CapStartupFilter>();
 
             return new CapBuilder(services);
-        }
-
-        private static void AddSubscribeServices(IServiceCollection services)
-        {
-            var consumerListenerServices = new List<KeyValuePair<Type, Type>>();
-            foreach (var rejectedServices in services)
-            {
-                if (rejectedServices.ImplementationType != null
-                    && typeof(ICapSubscribe).IsAssignableFrom(rejectedServices.ImplementationType))
-                {
-                    consumerListenerServices.Add(new KeyValuePair<Type, Type>(typeof(ICapSubscribe),
-                        rejectedServices.ImplementationType));
-                }
-            }
-
-            foreach (var service in consumerListenerServices)
-            {
-                services.TryAddEnumerable(ServiceDescriptor.Transient(service.Key, service.Value));
-            }
         }
     }
 }


### PR DESCRIPTION
现在查找 含 ICapSubscribe 接口的服务的方式，会**实例化**一次该服务类型。可能某些服务会在构造函数中有别的操作，会引起一些偏离设计的问题。

所以，将 IServiceCollection 保存起来，在 FindConsumersFromInterfaceTypes 方法中直接从 IServiceCollection 查找相关的服务，可以避免实例被创建。