### PR TITLE
Try to get the service instance using the serviceProvider.GetServices method.

### DIFF
--- a/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
+++ b/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        internal static IServiceCollection ServiceCollection;
         /// <summary>
         /// Adds and configures the consistence services for the consistency.
         /// </summary>
@@ -34,10 +35,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(setupAction));
             }
 
-            services.TryAddSingleton<CapMarkerService>();
+            ServiceCollection = services;
 
-            //Consumer service
-            AddSubscribeServices(services);
+            services.TryAddSingleton<CapMarkerService>();
 
             //Serializer and model binder
             services.TryAddSingleton<IContentSerializer, JsonContentSerializer>();
@@ -79,25 +79,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IStartupFilter, CapStartupFilter>();
 
             return new CapBuilder(services);
-        }
-
-        private static void AddSubscribeServices(IServiceCollection services)
-        {
-            var consumerListenerServices = new List<KeyValuePair<Type, Type>>();
-            foreach (var rejectedServices in services)
-            {
-                if (rejectedServices.ImplementationType != null
-                    && typeof(ICapSubscribe).IsAssignableFrom(rejectedServices.ImplementationType))
-                {
-                    consumerListenerServices.Add(new KeyValuePair<Type, Type>(typeof(ICapSubscribe),
-                        rejectedServices.ImplementationType));
-                }
-            }
-
-            foreach (var service in consumerListenerServices)
-            {
-                services.TryAddEnumerable(ServiceDescriptor.Transient(service.Key, service.Value));
-            }
         }
     }
 }

--- a/src/DotNetCore.CAP/ConsumerExecutorDescriptor.cs
+++ b/src/DotNetCore.CAP/ConsumerExecutorDescriptor.cs
@@ -11,6 +11,8 @@ namespace DotNetCore.CAP
     /// </summary>
     public class ConsumerExecutorDescriptor
     {
+        public TypeInfo ServiceTypeInfo { get; set; }
+
         public MethodInfo MethodInfo { get; set; }
 
         public TypeInfo ImplTypeInfo { get; set; }

--- a/src/DotNetCore.CAP/Internal/IConsumerInvoker.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerInvoker.Default.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,7 +42,18 @@ namespace DotNetCore.CAP.Internal
             {
                 var provider = scope.ServiceProvider;
                 var serviceType = context.ConsumerDescriptor.ImplTypeInfo.AsType();
-                var obj = ActivatorUtilities.GetServiceOrCreateInstance(provider, serviceType);
+                object obj = null;
+
+                if (context.ConsumerDescriptor.ServiceTypeInfo != null)
+                {
+                    obj = provider.GetServices(context.ConsumerDescriptor.ServiceTypeInfo.AsType())
+                        .FirstOrDefault(o => o.GetType() == serviceType);
+                }
+
+                if (obj == null)
+                {
+                    obj = ActivatorUtilities.GetServiceOrCreateInstance(provider, serviceType);
+                }
 
                 var jsonContent = context.DeliverMessage.Content;
                 var message = _messagePacker.UnPack(jsonContent);


### PR DESCRIPTION
**目前的方式是：**
1. 通过查找 IServiceCollection 中包含 ICapSubscribe 接口的服务实现类型，并重新注册到 ICapSubscribe 下。
2. 通过获取 ICapSubscribe 的全部服务来找到之前的服务实现类型，再找出其中的订阅方法。
3. 消息在执行的时候，尝试获取或创建该服务实现类型的服务。

**目前方法存在以下问题：**
1. 在第2步时，会实例化一次服务。
2. 在第3步，如果 ServiceType 和 ImplementationType 为不同类型时，此时又会实例化一次服务。
3. 对于注册为**Singleton**类型服务，会被非预期的实例化了多次。某些服务可能会在构造方法中执行其他操作，及执行的实例不一致，可能会导致一些非预期的结果。

**问题示例**
注册为**Singleton**类型服务，且 ServiceType 和 ImplementationType 为不同类型。服务内有个私有的缓存，在收到某个订阅消息后，清理部分缓存。

目前的方式，该服务类型实际上会被实例化了3个：注册为 ServiceType 的、注册为 ICapSubscribe 的，以及注册为 ImplementationType 的。

此时，在 Controller 或者其他服务中，通过 serviceProvider.GetService<ServiceType>() 获取到的实例，与 执行订阅消息的实例并不是同一个。导致该订阅消息没有在正确的实例上执行。

---------------------------

**本次提交的 patch 可解决以上问题：**
1. 直接从保存的 IServiceCollection 中查找包含 ICapSubscribe 接口的 ImplementationType，再找出其中的订阅方法并记录 ServiceType。
2. 在执行的时候，优先使用 serviceProvider.GetServices<ServiceType>() 获取服务并找到相应的实例。



