### PR TITLE
FindConsumersFromControllerTypes:  Search for controllers from AppDomaim.

### DIFF
--- a/src/DotNetCore.CAP/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/IConsumerServiceSelector.Default.cs
@@ -97,16 +97,17 @@ namespace DotNetCore.CAP
         {
             var executorDescriptorList = new List<ConsumerExecutorDescriptor>();
 
-            var types = Assembly.GetEntryAssembly().ExportedTypes;
-            foreach (var type in types)
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(o => !o.IsDynamic))
             {
-                var typeInfo = type.GetTypeInfo();
-                if (Helper.IsController(typeInfo))
+                foreach (var type in assembly.ExportedTypes)
                 {
-                    executorDescriptorList.AddRange(GetTopicAttributesDescription(typeInfo));
+                    var typeInfo = type.GetTypeInfo();
+                    if (Helper.IsController(typeInfo))
+                    {
+                        executorDescriptorList.AddRange(GetTopicAttributesDescription(typeInfo));
+                    }
                 }
             }
-
             return executorDescriptorList;
         }
 


### PR DESCRIPTION
Some controllers are outside of `Entry Assembly`. 

For example, some controllers are dynamically loaded using `_mvcBuilder.AddApplicationPart(assembly)`. 

Of course, you can also use [IActionDescriptorCollectionProvider](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.infrastructure.iactiondescriptorcollectionprovider?view=aspnetcore-2.2) to get all the controller information, but this needs to reference [Microsoft.AspNetCore.Mvc.Core](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Core/).