### PR TITLE
Write publish message store

### DIFF
--- a/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
+++ b/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
@@ -70,7 +70,10 @@ namespace DotNetCore.CAP.Abstractions
             {
                 var tracingResult = TracingBefore(message.Name, message.Content);
                 operationId = tracingResult.Item1;
-                message.Content = tracingResult.Item2;
+                
+                message.Content = tracingResult.Item2 != null
+                    ? Helper.AddTracingHeaderProperty(message.Content, tracingResult.Item2)
+                    : message.Content;
 
                 if (Transaction.Value?.DbTransaction == null)
                 {
@@ -103,7 +106,7 @@ namespace DotNetCore.CAP.Abstractions
             }
         }
         
-        private (Guid, string) TracingBefore(string topic, string values)
+        private (Guid, TracingHeaders) TracingBefore(string topic, string values)
         {
             Guid operationId = Guid.NewGuid();
             
@@ -115,7 +118,7 @@ namespace DotNetCore.CAP.Abstractions
 
             s_diagnosticListener.WritePublishMessageStoreBefore(eventData);
 
-            return (operationId, eventData.MessageContent);
+            return (operationId, eventData.Headers);
         }
 
         protected abstract Task ExecuteAsync(CapPublishedMessage message,

--- a/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
+++ b/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
@@ -68,7 +68,9 @@ namespace DotNetCore.CAP.Abstractions
 
             try
             {
-                operationId = s_diagnosticListener.WritePublishMessageStoreBefore(message);
+                var tracingResult = TracingBefore(message.Name, message.Content);
+                operationId = tracingResult.Item1;
+                message.Content = tracingResult.Item2;
 
                 if (Transaction.Value?.DbTransaction == null)
                 {
@@ -99,6 +101,21 @@ namespace DotNetCore.CAP.Abstractions
 
                 throw;
             }
+        }
+        
+        private (Guid, string) TracingBefore(string topic, string values)
+        {
+            Guid operationId = Guid.NewGuid();
+            
+            var eventData = new BrokerStoreEventData(
+                operationId, 
+                "",
+                topic, 
+                values);
+
+            s_diagnosticListener.WritePublishMessageStoreBefore(eventData);
+
+            return (operationId, eventData.MessageContent);
         }
 
         protected abstract Task ExecuteAsync(CapPublishedMessage message,

--- a/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
+++ b/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
@@ -38,26 +38,12 @@ namespace DotNetCore.CAP.Diagnostics
         //============================================================================
         //====================  Before publish store message      ====================
         //============================================================================
-        public static Guid WritePublishMessageStoreBefore(this DiagnosticListener @this,
-            CapPublishedMessage message,
-            [CallerMemberName] string operation = "")
+        public static void WritePublishMessageStoreBefore(this DiagnosticListener @this, BrokerStoreEventData eventData)
         {
             if (@this.IsEnabled(CapBeforePublishMessageStore))
             {
-                var operationId = Guid.NewGuid();
-
-                @this.Write(CapBeforePublishMessageStore, new
-                {
-                    OperationId = operationId,
-                    Operation = operation,
-                    MessageName = message.Name,
-                    MessageContent = message.Content
-                });
-
-                return operationId;
+                @this.Write(CapBeforePublishMessageStore, eventData);
             }
-
-            return Guid.Empty;
         }
 
         public static void WritePublishMessageStoreAfter(this DiagnosticListener @this,

--- a/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
+++ b/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
@@ -42,6 +42,7 @@ namespace DotNetCore.CAP.Diagnostics
         {
             if (@this.IsEnabled(CapBeforePublishMessageStore))
             {
+                eventData.Headers = new TracingHeaders();
                 @this.Write(CapBeforePublishMessageStore, eventData);
             }
         }

--- a/src/DotNetCore.CAP/Diagnostics/EventData.Broker.Store.cs
+++ b/src/DotNetCore.CAP/Diagnostics/EventData.Broker.Store.cs
@@ -16,5 +16,7 @@ namespace DotNetCore.CAP.Diagnostics
         
         public string MessageName { get; set; }
         public string MessageContent { get; set; }
+        
+        public TracingHeaders Headers { get; set; } 
     }
 }

--- a/src/DotNetCore.CAP/Diagnostics/EventData.Broker.Store.cs
+++ b/src/DotNetCore.CAP/Diagnostics/EventData.Broker.Store.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DotNetCore.CAP.Diagnostics
+{
+    public class BrokerStoreEventData : EventData
+    {
+        public BrokerStoreEventData(
+            Guid operationId, 
+            string operation,
+            string messageName, 
+            string messageContent) : base(operationId, operation)
+        {
+            MessageName = messageName;
+            MessageContent = messageContent;
+        }
+        
+        public string MessageName { get; set; }
+        public string MessageContent { get; set; }
+    }
+}


### PR DESCRIPTION
With these changes, it will be possible to add TracingHeaders to message on `CapBeforePublishMessageStore` event just like before `WritePublishBefore` and `WriteConsumeBefore` (although Headers property doesn't work for `WriteConsumeBefore`, at least I can change message Content directly)