### PR TITLE
change DashboardMiddleware to async

### DIFF
--- a/src/DotNetCore.CAP/Dashboard/IDashboardAuthorizationFilter.cs
+++ b/src/DotNetCore.CAP/Dashboard/IDashboardAuthorizationFilter.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+
 namespace DotNetCore.CAP.Dashboard
 {
     public interface IDashboardAuthorizationFilter
     {
-        bool Authorize(DashboardContext context);
+        Task<bool> AuthorizeAsync(DashboardContext context);
     }
 }

--- a/src/DotNetCore.CAP/Dashboard/LocalRequestsOnlyAuthorizationFilter.cs
+++ b/src/DotNetCore.CAP/Dashboard/LocalRequestsOnlyAuthorizationFilter.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using DotNetCore.CAP.Infrastructure;
 
 namespace DotNetCore.CAP.Dashboard
 {
     public class LocalRequestsOnlyAuthorizationFilter : IDashboardAuthorizationFilter
     {
-        public bool Authorize(DashboardContext context)
+#pragma warning disable 1998
+        public async Task<bool> AuthorizeAsync(DashboardContext context)
+#pragma warning restore 1998
         {
             var ipAddress = context.Request.RemoteIpAddress;
             // if unknown, assume not local


### PR DESCRIPTION
在自定义IDashboardAuthorizationFilter 的过程中,我发现在Authorize里无法使用异步方法,而观察asp.net core原生代码,这类方法多是支持异步的.

https://github.com/aspnet/Security/blob/26d27d871b7992022c082dc207e3d126e1d9d278/src/Microsoft.AspNetCore.Authentication/AuthenticationMiddleware.cs#L54
 
期待改进