### PR TITLE
Add kafka key to publishing

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/IPublishMessageSender.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/IPublishMessageSender.AzureServiceBus.cs
@@ -36,7 +36,7 @@ namespace DotNetCore.CAP.AzureServiceBus
 
         protected override string ServersAddress => _asbOptions.Value.ConnectionString;
 
-        public override async Task<OperateResult> PublishAsync(string keyName, string content)
+        public override async Task<OperateResult> PublishAsync(string keyName, string content, string key = null)
         {
             try
             {

--- a/src/DotNetCore.CAP.InMemoryStorage/IStorageTransaction.InMemory.cs
+++ b/src/DotNetCore.CAP.InMemoryStorage/IStorageTransaction.InMemory.cs
@@ -30,6 +30,7 @@ namespace DotNetCore.CAP.InMemoryStorage
             msg.Content = message.Content;
             msg.ExpiresAt = message.ExpiresAt;
             msg.StatusName = message.StatusName;
+            msg.Key = message.Key;
         }
 
         public void UpdateMessage(CapReceivedMessage message)
@@ -44,6 +45,7 @@ namespace DotNetCore.CAP.InMemoryStorage
             msg.Content = message.Content;
             msg.ExpiresAt = message.ExpiresAt;
             msg.StatusName = message.StatusName;
+            msg.Key = message.Key;
         }
 
         public Task CommitAsync()

--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -14,14 +14,14 @@ namespace DotNetCore.CAP.Kafka
     public class ConnectionPool : IConnectionPool, IDisposable
     {
         private readonly KafkaOptions _options;
-        private readonly ConcurrentQueue<IProducer<Null, string>> _producerPool;
+        private readonly ConcurrentQueue<IProducer<string, string>> _producerPool;
         private int _pCount;
         private int _maxSize;
 
         public ConnectionPool(ILogger<ConnectionPool> logger, IOptions<KafkaOptions> options)
         {
             _options = options.Value;
-            _producerPool = new ConcurrentQueue<IProducer<Null, string>>();
+            _producerPool = new ConcurrentQueue<IProducer<string, string>>();
             _maxSize = _options.ConnectionPoolSize;
              
             logger.LogDebug("Kafka configuration of CAP :\r\n {0}", JsonConvert.SerializeObject(_options.AsKafkaConfig(), Formatting.Indented));
@@ -29,7 +29,7 @@ namespace DotNetCore.CAP.Kafka
 
         public string ServersAddress => _options.Servers;
 
-        public IProducer<Null, string> RentProducer()
+        public IProducer<string, string> RentProducer()
         {
             if (_producerPool.TryDequeue(out var producer))
             {
@@ -38,12 +38,12 @@ namespace DotNetCore.CAP.Kafka
                 return producer;
             }
 
-            producer = new ProducerBuilder<Null, string>(_options.AsKafkaConfig()).Build();
+            producer = new ProducerBuilder<string, string>(_options.AsKafkaConfig()).Build();
 
             return producer;
         }
 
-        public bool Return(IProducer<Null, string> producer)
+        public bool Return(IProducer<string, string> producer)
         {
             if (Interlocked.Increment(ref _pCount) <= _maxSize)
             {

--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.cs
@@ -9,8 +9,8 @@ namespace DotNetCore.CAP.Kafka
     {
         string ServersAddress { get; }
 
-        IProducer<Null,string> RentProducer();
+        IProducer<string,string> RentProducer();
 
-        bool Return(IProducer<Null, string> producer);
+        bool Return(IProducer<string, string> producer);
     }
 }

--- a/src/DotNetCore.CAP.Kafka/IPublishMessageSender.Kafka.cs
+++ b/src/DotNetCore.CAP.Kafka/IPublishMessageSender.Kafka.cs
@@ -30,20 +30,21 @@ namespace DotNetCore.CAP.Kafka
 
         protected override string ServersAddress => _connectionPool.ServersAddress;
 
-        public override async Task<OperateResult> PublishAsync(string keyName, string content)
+        public override async Task<OperateResult> PublishAsync(string topicName, string content, string key = null)
         {
             var producer = _connectionPool.RentProducer();
 
             try
             {
-                var result = await producer.ProduceAsync(keyName, new Message<Null, string>()
+                var result = await producer.ProduceAsync(topicName, new Message<string, string>()
                 {
-                    Value = content
+                    Value = content,
+                    Key = key
                 });
 
                 if (result.Status == PersistenceStatus.Persisted || result.Status == PersistenceStatus.PossiblyPersisted)
                 {
-                    _logger.LogDebug($"kafka topic message [{keyName}] has been published.");
+                    _logger.LogDebug($"kafka topic message [{topicName}] has been published.");
 
                     return OperateResult.Success;
                 }

--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -15,7 +15,7 @@ namespace DotNetCore.CAP.Kafka
 
         private readonly string _groupId;
         private readonly KafkaOptions _kafkaOptions;
-        private IConsumer<Null, string> _consumerClient;
+        private IConsumer<string, string> _consumerClient;
 
         public KafkaConsumerClient(string groupId, IOptions<KafkaOptions> options)
         {
@@ -55,6 +55,7 @@ namespace DotNetCore.CAP.Kafka
                 {
                     Group = _groupId,
                     Name = consumerResult.Topic,
+                    Key = consumerResult.Key,
                     Content = consumerResult.Value
                 };
 
@@ -97,7 +98,7 @@ namespace DotNetCore.CAP.Kafka
                     _kafkaOptions.MainConfig["auto.offset.reset"] = "earliest";
                     var config = _kafkaOptions.AsKafkaConfig();
 
-                    _consumerClient = new ConsumerBuilder<Null, string>(config)
+                    _consumerClient = new ConsumerBuilder<string, string>(config)
                         .SetErrorHandler(ConsumerClient_OnConsumeError)
                         .Build();
                 }
@@ -108,7 +109,7 @@ namespace DotNetCore.CAP.Kafka
             } 
         }
 
-        private void ConsumerClient_OnConsumeError(IConsumer<Null, string> consumer, Error e)
+        private void ConsumerClient_OnConsumeError(IConsumer<string, string> consumer, Error e)
         {
             var logArgs = new LogMessageEventArgs
             {

--- a/src/DotNetCore.CAP.MongoDB/ICapPublisher.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/ICapPublisher.MongoDB.cs
@@ -48,6 +48,7 @@ namespace DotNetCore.CAP.MongoDB
                 ExpiresAt = message.ExpiresAt,
                 Retries = message.Retries,
                 Version = _options.Version,
+                Key = message.Key,
             };
 
             if (transaction == null)

--- a/src/DotNetCore.CAP.MongoDB/IStorage.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorage.MongoDB.cs
@@ -64,11 +64,11 @@ namespace DotNetCore.CAP.MongoDB
 
             var receivedMessageIndexNames = new[] {
                 nameof(ReceivedMessage.Name), nameof(ReceivedMessage.Added), nameof(ReceivedMessage.ExpiresAt),
-                nameof(ReceivedMessage.StatusName), nameof(ReceivedMessage.Retries), nameof(ReceivedMessage.Version) };
+                nameof(ReceivedMessage.StatusName), nameof(ReceivedMessage.Retries), nameof(ReceivedMessage.Version), nameof(ReceivedMessage.Key) };
 
             var publishedMessageIndexNames = new[] {
                 nameof(PublishedMessage.Name), nameof(PublishedMessage.Added), nameof(PublishedMessage.ExpiresAt),
-                nameof(PublishedMessage.StatusName), nameof(PublishedMessage.Retries), nameof(PublishedMessage.Version) };
+                nameof(PublishedMessage.StatusName), nameof(PublishedMessage.Retries), nameof(PublishedMessage.Version), nameof(PublishedMessage.Key) };
 
             await Task.WhenAll(
                 TryCreateIndexesAsync<ReceivedMessage>(options.ReceivedCollection, receivedMessageIndexNames),

--- a/src/DotNetCore.CAP.MongoDB/IStorageConnection.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorageConnection.MongoDB.cs
@@ -121,7 +121,8 @@ namespace DotNetCore.CAP.MongoDB
                 StatusName = message.StatusName,
                 ExpiresAt = message.ExpiresAt,
                 Retries = message.Retries,
-                Version = _capOptions.Version
+                Version = _capOptions.Version,
+                Key = message.Key,
             };
 
             collection.InsertOne(store);

--- a/src/DotNetCore.CAP.MongoDB/IStorageTransaction.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorageTransaction.MongoDB.cs
@@ -45,7 +45,8 @@ namespace DotNetCore.CAP.MongoDB
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.Content, message.Content)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)
-                .Set(x => x.StatusName, message.StatusName);
+                .Set(x => x.StatusName, message.StatusName)
+                .Set(x => x.Key, message.Key);
 
             collection.FindOneAndUpdate(_session, x => x.Id == message.Id, updateDef);
         }
@@ -63,7 +64,8 @@ namespace DotNetCore.CAP.MongoDB
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.Content, message.Content)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)
-                .Set(x => x.StatusName, message.StatusName);
+                .Set(x => x.StatusName, message.StatusName)
+                .Set(x => x.Key, message.Key);
 
             collection.FindOneAndUpdate(_session, x => x.Id == message.Id, updateDef);
         }

--- a/src/DotNetCore.CAP.MySql/ICapPublisher.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/ICapPublisher.MySql.cs
@@ -57,8 +57,8 @@ namespace DotNetCore.CAP.MySql
         private string PrepareSql()
         {
             return
-                $"INSERT INTO `{_options.TableNamePrefix}.published` (`Id`,`Version`,`Name`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`)" +
-                $"VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
+                $"INSERT INTO `{_options.TableNamePrefix}.published` (`Id`,`Version`,`Name`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`,`Key`)" +
+                $"VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key);";
         }
 
         #endregion private methods

--- a/src/DotNetCore.CAP.MySql/IStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorage.MySql.cs
@@ -70,8 +70,13 @@ CREATE TABLE IF NOT EXISTS `{prefix}.received` (
   `Added` datetime NOT NULL,
   `ExpiresAt` datetime DEFAULT NULL,
   `StatusName` varchar(50) NOT NULL,
+  `Key` longtext DEFAULT NULL,
   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
+           WHERE TABLE_NAME = '{prefix}.received' AND COLUMN_NAME = 'Key' ) 
+ALTER TABLE MLReport ADD `Key` longtext DEFAULT NULL;
 
 CREATE TABLE IF NOT EXISTS `{prefix}.published` (
   `Id` bigint NOT NULL,
@@ -82,8 +87,13 @@ CREATE TABLE IF NOT EXISTS `{prefix}.published` (
   `Added` datetime NOT NULL,
   `ExpiresAt` datetime DEFAULT NULL,
   `StatusName` varchar(40) NOT NULL,
+  `Key` longtext DEFAULT NULL,
   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
+           WHERE TABLE_NAME = '{prefix}.published' AND COLUMN_NAME = 'Key' ) 
+ALTER TABLE MLReport ADD `Key` longtext DEFAULT NULL;
 ";
             return batchSql;
         }

--- a/src/DotNetCore.CAP.MySql/IStorageConnection.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorageConnection.MySql.cs
@@ -62,8 +62,8 @@ namespace DotNetCore.CAP.MySql
             }
 
             var sql = $@"
-INSERT INTO `{_prefix}.received`(`Id`,`Version`,`Name`,`Group`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`)
-VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
+INSERT INTO `{_prefix}.received`(`Id`,`Version`,`Name`,`Group`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`,`Key`)
+VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key);";
 
             using (var connection = new MySqlConnection(Options.ConnectionString))
             {

--- a/src/DotNetCore.CAP.MySql/IStorageTransaction.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorageTransaction.MySql.cs
@@ -32,7 +32,7 @@ namespace DotNetCore.CAP.MySql
             }
 
             var sql =
-                $"UPDATE `{_prefix}.published` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
+                $"UPDATE `{_prefix}.published` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName,`Key`=@Key WHERE `Id`=@Id;";
             _dbConnection.Execute(sql, message);
         }
 
@@ -44,7 +44,7 @@ namespace DotNetCore.CAP.MySql
             }
 
             var sql =
-                $"UPDATE `{_prefix}.received` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
+                $"UPDATE `{_prefix}.received` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName,`Key`=@Key WHERE `Id`=@Id;";
             _dbConnection.Execute(sql, message);
         }
 

--- a/src/DotNetCore.CAP.PostgreSql/ICapPublisher.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/ICapPublisher.PostgreSql.cs
@@ -56,7 +56,7 @@ namespace DotNetCore.CAP.PostgreSql
         private string PrepareSql()
         {
             return
-                $"INSERT INTO \"{_options.Schema}\".\"published\" (\"Id\",\"Version\",\"Name\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"StatusName\")VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
+                $"INSERT INTO \"{_options.Schema}\".\"published\" (\"Id\",\"Version\",\"Name\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"StatusName\",\"Key\")VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key);";
         }
 
         private IDbConnection InitDbConnection()

--- a/src/DotNetCore.CAP.PostgreSql/IStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorage.PostgreSql.cs
@@ -110,7 +110,8 @@ CREATE TABLE IF NOT EXISTS ""{schema}"".""received""(
 	""Retries"" INT NOT NULL,
 	""Added"" TIMESTAMP NOT NULL,
     ""ExpiresAt"" TIMESTAMP NULL,
-	""StatusName"" VARCHAR(50) NOT NULL
+	""StatusName"" VARCHAR(50) NOT NULL,
+    ""Key"" TEXT NULL
 );
 
 CREATE TABLE IF NOT EXISTS ""{schema}"".""published""(
@@ -121,11 +122,15 @@ CREATE TABLE IF NOT EXISTS ""{schema}"".""published""(
 	""Retries"" INT NOT NULL,
 	""Added"" TIMESTAMP NOT NULL,
     ""ExpiresAt"" TIMESTAMP NULL,
-	""StatusName"" VARCHAR(50) NOT NULL
+	""StatusName"" VARCHAR(50) NOT NULL,
+    ""Key"" TEXT NULL
 );
 
 ALTER TABLE ""{schema}"".""received"" ADD COLUMN IF NOT EXISTS ""Version"" VARCHAR(20) NOT NULL;
 ALTER TABLE ""{schema}"".""published"" ADD COLUMN IF NOT EXISTS ""Version"" VARCHAR(20) NOT NULL;
+
+ALTER TABLE ""{schema}"".""received"" ADD COLUMN IF NOT EXISTS ""Key"" TEXT NULL;
+ALTER TABLE ""{schema}"".""published"" ADD COLUMN IF NOT EXISTS ""Key"" TEXT NULL;
 ";
             return batchSql;
         }

--- a/src/DotNetCore.CAP.PostgreSql/IStorageConnection.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorageConnection.PostgreSql.cs
@@ -61,7 +61,7 @@ namespace DotNetCore.CAP.PostgreSql
             }
 
             var sql =
-                $"INSERT INTO \"{Options.Schema}\".\"received\"(\"Id\",\"Version\",\"Name\",\"Group\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"StatusName\")VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName) RETURNING \"Id\";";
+                $"INSERT INTO \"{Options.Schema}\".\"received\"(\"Id\",\"Version\",\"Name\",\"Group\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"StatusName\",\"Key\")VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key) RETURNING \"Id\";";
 
             using (var connection = new NpgsqlConnection(Options.ConnectionString))
             {

--- a/src/DotNetCore.CAP.PostgreSql/IStorageTransaction.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorageTransaction.PostgreSql.cs
@@ -35,7 +35,7 @@ namespace DotNetCore.CAP.PostgreSql
             }
 
             var sql =
-                $@"UPDATE ""{_schema}"".""published"" SET ""Retries""=@Retries,""Content""= @Content,""ExpiresAt""=@ExpiresAt,""StatusName""=@StatusName WHERE ""Id""=@Id;";
+                $@"UPDATE ""{_schema}"".""published"" SET ""Retries""=@Retries,""Content""= @Content,""ExpiresAt""=@ExpiresAt,""StatusName""=@StatusName,""Key""=@Key WHERE ""Id""=@Id;";
             _dbConnection.Execute(sql, message, _dbTransaction);
         }
 
@@ -47,7 +47,7 @@ namespace DotNetCore.CAP.PostgreSql
             }
 
             var sql =
-                $@"UPDATE ""{_schema}"".""received"" SET ""Retries""=@Retries,""Content""= @Content,""ExpiresAt""=@ExpiresAt,""StatusName""=@StatusName WHERE ""Id""=@Id;";
+                $@"UPDATE ""{_schema}"".""received"" SET ""Retries""=@Retries,""Content""= @Content,""ExpiresAt""=@ExpiresAt,""StatusName""=@StatusName,""Key""=@Key WHERE ""Id""=@Id;";
             _dbConnection.Execute(sql, message, _dbTransaction);
         }
 

--- a/src/DotNetCore.CAP.RabbitMQ/IPublishMessageSender.RabbitMQ.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/IPublishMessageSender.RabbitMQ.cs
@@ -34,7 +34,7 @@ namespace DotNetCore.CAP.RabbitMQ
 
         protected override string ServersAddress => _connectionChannelPool.HostAddress;
 
-        public override Task<OperateResult> PublishAsync(string keyName, string content)
+        public override Task<OperateResult> PublishAsync(string keyName, string content, string key = null)
         {
             var channel = _connectionChannelPool.Rent();
             try

--- a/src/DotNetCore.CAP.SqlServer/ICapPublisher.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/ICapPublisher.SqlServer.cs
@@ -56,7 +56,7 @@ namespace DotNetCore.CAP.SqlServer
         private string PrepareSql()
         {
             return
-                $"INSERT INTO {_options.Schema}.[Published] ([Id],[Version],[Name],[Content],[Retries],[Added],[ExpiresAt],[StatusName])VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
+                $"INSERT INTO {_options.Schema}.[Published] ([Id],[Version],[Name],[Content],[Retries],[Added],[ExpiresAt],[StatusName],[Key])VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key);";
         }
 
         #endregion private methods

--- a/src/DotNetCore.CAP.SqlServer/IStorage.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorage.SqlServer.cs
@@ -93,6 +93,12 @@ CREATE TABLE [{schema}].[Received](
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 END;
 
+IF COL_LENGTH('{schema}.Received', 'Key') IS NULL
+BEGIN
+    ALTER TABLE [{schema}].[Received]
+    ADD [Key] [nvarchar](max) NULL
+END;
+
 IF OBJECT_ID(N'[{schema}].[Published]',N'U') IS NULL
 BEGIN
 CREATE TABLE [{schema}].[Published](
@@ -110,6 +116,12 @@ CREATE TABLE [{schema}].[Published](
 	[Id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END;
+
+IF COL_LENGTH('{schema}.Published', 'Key') IS NULL
+BEGIN
+    ALTER TABLE [{schema}].[Published]
+    ADD [Key] [nvarchar](max) NULL
 END;";
             return batchSql;
         }

--- a/src/DotNetCore.CAP.SqlServer/IStorage.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorage.SqlServer.cs
@@ -85,6 +85,7 @@ CREATE TABLE [{schema}].[Received](
 	[Added] [datetime2](7) NOT NULL,
     [ExpiresAt] [datetime2](7) NULL,
 	[StatusName] [nvarchar](50) NOT NULL,
+    [Key] [nvarchar](max) NULL,
  CONSTRAINT [PK_{schema}.Received] PRIMARY KEY CLUSTERED
 (
 	[Id] ASC
@@ -103,6 +104,7 @@ CREATE TABLE [{schema}].[Published](
 	[Added] [datetime2](7) NOT NULL,
     [ExpiresAt] [datetime2](7) NULL,
 	[StatusName] [nvarchar](50) NOT NULL,
+    [Key] [nvarchar](max) NULL,
  CONSTRAINT [PK_{schema}.Published] PRIMARY KEY CLUSTERED
 (
 	[Id] ASC

--- a/src/DotNetCore.CAP.SqlServer/IStorageConnection.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorageConnection.SqlServer.cs
@@ -61,8 +61,8 @@ namespace DotNetCore.CAP.SqlServer
             }
 
             var sql = $@"
-INSERT INTO [{Options.Schema}].[Received]([Id],[Version],[Name],[Group],[Content],[Retries],[Added],[ExpiresAt],[StatusName])
-VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
+INSERT INTO [{Options.Schema}].[Received]([Id],[Version],[Name],[Group],[Content],[Retries],[Added],[ExpiresAt],[StatusName],[Key])
+VALUES(@Id,'{_capOptions.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName,@Key);";
 
             using (var connection = new SqlConnection(Options.ConnectionString))
             {

--- a/src/DotNetCore.CAP.SqlServer/IStorageTransaction.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorageTransaction.SqlServer.cs
@@ -32,7 +32,7 @@ namespace DotNetCore.CAP.SqlServer
             }
 
             var sql =
-                $"UPDATE [{_schema}].[Published] SET [Retries] = @Retries,[Content] = @Content,[ExpiresAt] = @ExpiresAt,[StatusName]=@StatusName WHERE Id=@Id;";
+                $"UPDATE [{_schema}].[Published] SET [Retries] = @Retries,[Content] = @Content,[ExpiresAt] = @ExpiresAt,[StatusName]=@StatusName,[Key]=@Key WHERE Id=@Id;";
             _dbConnection.Execute(sql, message);
         }
 
@@ -44,7 +44,7 @@ namespace DotNetCore.CAP.SqlServer
             }
 
             var sql =
-                $"UPDATE [{_schema}].[Received] SET [Retries] = @Retries,[Content] = @Content,[ExpiresAt] = @ExpiresAt,[StatusName]=@StatusName WHERE Id=@Id;";
+                $"UPDATE [{_schema}].[Received] SET [Retries] = @Retries,[Content] = @Content,[ExpiresAt] = @ExpiresAt,[StatusName]=@StatusName,[Key]=@Key WHERE Id=@Id;";
             _dbConnection.Execute(sql, message);
         }
 

--- a/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
+++ b/src/DotNetCore.CAP/Abstractions/CapPublisherBase.cs
@@ -35,7 +35,7 @@ namespace DotNetCore.CAP.Abstractions
 
         public AsyncLocal<ICapTransaction> Transaction { get; }
 
-        public void Publish<T>(string name, T contentObj, string callbackName = null)
+        public void Publish<T>(string name, T contentObj, string callbackName = null, string key = null)
         {
             var message = new CapPublishedMessage
             {
@@ -44,11 +44,15 @@ namespace DotNetCore.CAP.Abstractions
                 Content = Serialize(contentObj, callbackName),
                 StatusName = StatusName.Scheduled
             };
+            if (!string.IsNullOrEmpty(key))
+            {
+                message.Key = key;
+            }
 
             PublishAsyncInternal(message).GetAwaiter().GetResult();
         }
 
-        public async Task PublishAsync<T>(string name, T contentObj, string callbackName = null,
+        public async Task PublishAsync<T>(string name, T contentObj, string callbackName = null, string key = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var message = new CapPublishedMessage
@@ -58,6 +62,11 @@ namespace DotNetCore.CAP.Abstractions
                 Content = Serialize(contentObj, callbackName),
                 StatusName = StatusName.Scheduled
             };
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                message.Key = key;
+            }
 
             await PublishAsyncInternal(message);
         }

--- a/src/DotNetCore.CAP/Dashboard/Monitoring/MessageDto.cs
+++ b/src/DotNetCore.CAP/Dashboard/Monitoring/MessageDto.cs
@@ -24,5 +24,7 @@ namespace DotNetCore.CAP.Dashboard.Monitoring
         public int Retries { get; set; }
 
         public string StatusName { get; set; }
+
+        public string Key { get; set; }
     }
 }

--- a/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
+++ b/src/DotNetCore.CAP/Diagnostics/DiagnosticListenerExtensions.cs
@@ -61,6 +61,7 @@ namespace DotNetCore.CAP.Diagnostics
                     MessageId = message.Id,
                     MessageName = message.Name,
                     MessageContent = message.Content,
+                    MessageKey = message.Key,
                     Timestamp = Stopwatch.GetTimestamp()
                 });
             }
@@ -80,6 +81,7 @@ namespace DotNetCore.CAP.Diagnostics
                     Operation = operation,
                     MessageName = message.Name,
                     MessageContent = message.Content,
+                    MessageKey = message.Key,
                     Exception = ex,
                     Timestamp = Stopwatch.GetTimestamp()
                 });

--- a/src/DotNetCore.CAP/ICapPublisher.cs
+++ b/src/DotNetCore.CAP/ICapPublisher.cs
@@ -25,8 +25,9 @@ namespace DotNetCore.CAP
         /// <param name="name">the topic name or exchange router key.</param>
         /// <param name="contentObj">message body content, that will be serialized of json.</param>
         /// <param name="callbackName">callback subscriber name</param>
+        /// <param name="key">kafka message key</param>
         /// <param name="cancellationToken"></param>
-        Task PublishAsync<T>(string name, T contentObj, string callbackName = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task PublishAsync<T>(string name, T contentObj, string callbackName = null, string key = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Publish an object message.
@@ -34,6 +35,7 @@ namespace DotNetCore.CAP
         /// <param name="name">the topic name or exchange router key.</param>
         /// <param name="contentObj">message body content, that will be serialized of json.</param>
         /// <param name="callbackName">callback subscriber name</param>
-        void Publish<T>(string name, T contentObj, string callbackName = null);
+        /// <param name="key">kafka message key</param>
+        void Publish<T>(string name, T contentObj, string callbackName = null, string key = null);
     }
 }

--- a/src/DotNetCore.CAP/IConsumerRegister.Default.cs
+++ b/src/DotNetCore.CAP/IConsumerRegister.Default.cs
@@ -159,7 +159,8 @@ namespace DotNetCore.CAP
                 {
                     Id = SnowflakeId.Default().NextId(),
                     StatusName = StatusName.Scheduled,
-                    Content = messageBody
+                    Content = messageBody,
+                    Key = messageContext.Key
                 };
 
                 try

--- a/src/DotNetCore.CAP/IPublishExecutor.cs
+++ b/src/DotNetCore.CAP/IPublishExecutor.cs
@@ -15,7 +15,8 @@ namespace DotNetCore.CAP
         /// </summary>
         /// <param name="keyName">The message topic name.</param>
         /// <param name="content">The message content.</param>
+        /// <param name="key">The message key (Kafka).</param>
         /// <returns></returns>
-        Task<OperateResult> PublishAsync(string keyName, string content);
+        Task<OperateResult> PublishAsync(string keyName, string content, string key = null);
     }
 }

--- a/src/DotNetCore.CAP/IPublishMessageSender.Base.cs
+++ b/src/DotNetCore.CAP/IPublishMessageSender.Base.cs
@@ -41,7 +41,7 @@ namespace DotNetCore.CAP
             _logger = logger;
         }
 
-        public abstract Task<OperateResult> PublishAsync(string keyName, string content);
+        public abstract Task<OperateResult> PublishAsync(string keyName, string content, string key = null);
 
         public async Task<OperateResult> SendAsync(CapPublishedMessage message)
         {
@@ -73,7 +73,7 @@ namespace DotNetCore.CAP
                 ? Helper.AddTracingHeaderProperty(message.Content, tracingResult.Item2)
                 : message.Content;
 
-            var result = await PublishAsync(message.Name, sendValues);
+            var result = await PublishAsync(message.Name, sendValues, message.Key);
 
             stopwatch.Stop();
             if (result.Succeeded)

--- a/src/DotNetCore.CAP/MessageContext.cs
+++ b/src/DotNetCore.CAP/MessageContext.cs
@@ -23,11 +23,23 @@ namespace DotNetCore.CAP
         /// <summary>
         /// Message content
         /// </summary>
-        public string Content { get; set; } 
+        public string Content { get; set; }
+        
+        /// <summary>
+        /// Message key (Kafka).
+        /// </summary>
+        public string Key { get; set; }
 
         public override string ToString()
         {
-            return $"Group:{Group}, Name:{Name}, Content:{Content}";
+            if (string.IsNullOrEmpty(Key))
+            {
+                return $"Group:{Group}, Name:{Name}, Content:{Content}";
+            }
+            else
+            {
+                return $"Group:{Group}, Name:{Name}, Key:{Key}, Content:{Content}";
+            }
         }
     }
 }

--- a/src/DotNetCore.CAP/Models/CapMessageDto.cs
+++ b/src/DotNetCore.CAP/Models/CapMessageDto.cs
@@ -15,6 +15,7 @@ namespace DotNetCore.CAP.Models
         public virtual string Content { get; set; }
 
         public virtual string CallbackName { get; set; }
+
     }
 
     public sealed class CapMessageDto : CapMessage
@@ -37,5 +38,6 @@ namespace DotNetCore.CAP.Models
         public override string Content { get; set; }
 
         public override string CallbackName { get; set; }
+
     }
 }

--- a/src/DotNetCore.CAP/Models/CapPublishedMessage.cs
+++ b/src/DotNetCore.CAP/Models/CapPublishedMessage.cs
@@ -29,9 +29,18 @@ namespace DotNetCore.CAP.Models
 
         public string StatusName { get; set; }
 
+        public string Key { get; set; }
+
         public override string ToString()
         {
-            return "name:" + Name + ", content:" + Content;
+            if (string.IsNullOrEmpty(Key))
+            {
+                return "name:" + Name + ", content:" + Content;
+            }
+            else
+            {
+                return $"name:{Name}, key:{Key}, content:{Content}";
+            }
         }
     }
 }

--- a/src/DotNetCore.CAP/Models/CapReceivedMessage.cs
+++ b/src/DotNetCore.CAP/Models/CapReceivedMessage.cs
@@ -20,6 +20,7 @@ namespace DotNetCore.CAP.Models
             Group = message.Group;
             Name = message.Name;
             Content = message.Content;
+            Key = message.Key;
         }
 
         public long Id { get; set; }
@@ -38,13 +39,16 @@ namespace DotNetCore.CAP.Models
 
         public string StatusName { get; set; }
 
+        public string Key { get; set; }
+
         public MessageContext ToMessageContext()
         {
             return new MessageContext
             {
                 Group = Group,
                 Name = Name,
-                Content = Content
+                Content = Content,
+                Key = Key
             };
         }
 

--- a/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
+++ b/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
@@ -124,13 +124,13 @@ namespace DotNetCore.CAP.Test
 
             public AsyncLocal<ICapTransaction> Transaction { get; }
 
-            public Task PublishAsync<T>(string name, T contentObj, string callbackName = null,
+            public Task PublishAsync<T>(string name, T contentObj, string callbackName = null, string key = null,
                 CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public void Publish<T>(string name, T contentObj, string callbackName = null)
+            public void Publish<T>(string name, T contentObj, string callbackName = null, string key = null)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
This PR adds the ability to send a string as a key in Kafka. The interface was modified to include the key as an optional parameter, which all message queue implementations ignore except Kafka. DB schemas were also updated to add the column if it doesn't exist.