### PR TITLE
Store CAP data in a MySql database different from your business

### DIFF
--- a/src/DotNetCore.CAP.MySql/CAP.MySqlOptions.cs
+++ b/src/DotNetCore.CAP.MySql/CAP.MySqlOptions.cs
@@ -17,14 +17,11 @@ namespace DotNetCore.CAP
         /// </summary>
         public string ConnectionString
         {
-            get
-            {
-                return _connectionString;
-            }
+            get => _connectionString;
             set
             {
-                MySqlConnection mySqlConnection = new MySqlConnection(value);
-                DatabaseName = mySqlConnection.Database;
+                MySqlConnectionStringBuilder builder = new MySqlConnectionStringBuilder(value);
+                DatabaseName = builder.Database;
                 _connectionString = value;
             }
         }

--- a/src/DotNetCore.CAP.MySql/CAP.MySqlOptions.cs
+++ b/src/DotNetCore.CAP.MySql/CAP.MySqlOptions.cs
@@ -4,15 +4,35 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
 
 namespace DotNetCore.CAP
 {
     public class MySqlOptions : EFOptions
     {
+        private string _connectionString;
+
         /// <summary>
         /// Gets or sets the database's connection string that will be used to store database entities.
         /// </summary>
-        public string ConnectionString { get; set; }
+        public string ConnectionString
+        {
+            get
+            {
+                return _connectionString;
+            }
+            set
+            {
+                MySqlConnection mySqlConnection = new MySqlConnection(value);
+                DatabaseName = mySqlConnection.Database;
+                _connectionString = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the database's Name.
+        /// </summary>
+        public string DatabaseName { get; set; }
     }
 
     internal class ConfigureMySqlOptions : IConfigureOptions<MySqlOptions>

--- a/src/DotNetCore.CAP.MySql/ICapPublisher.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/ICapPublisher.MySql.cs
@@ -57,7 +57,7 @@ namespace DotNetCore.CAP.MySql
         private string PrepareSql()
         {
             return
-                $"INSERT INTO `{_options.TableNamePrefix}.published` (`Id`,`Version`,`Name`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`)" +
+                $"INSERT INTO `{_options.DatabaseName}`.`{_options.TableNamePrefix}.published` (`Id`,`Version`,`Name`,`Content`,`Retries`,`Added`,`ExpiresAt`,`StatusName`)" +
                 $"VALUES(@Id,'{_options.Version}',@Name,@Content,@Retries,@Added,@ExpiresAt,@StatusName);";
         }
 

--- a/src/DotNetCore.CAP.MySql/ICollectProcessor.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/ICollectProcessor.MySql.cs
@@ -43,7 +43,7 @@ namespace DotNetCore.CAP.MySql
                     using (var connection = new MySqlConnection(_options.ConnectionString))
                     {
                         removedCount = await connection.ExecuteAsync(
-                            $@"DELETE FROM `{table}` WHERE ExpiresAt < @now limit @count;",
+                            $@"DELETE FROM `{_options.DatabaseName}`.`{table}` WHERE ExpiresAt < @now limit @count;",
                             new { now = DateTime.Now, count = MaxBatch });
                     }
 

--- a/src/DotNetCore.CAP.MySql/IStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorage.MySql.cs
@@ -22,7 +22,7 @@ namespace DotNetCore.CAP.MySql
 
         public MySqlStorage(
             ILogger<MySqlStorage> logger,
-            IOptions<MySqlOptions> options, 
+            IOptions<MySqlOptions> options,
             IOptions<CapOptions> capOptions)
         {
             _options = options;
@@ -47,7 +47,7 @@ namespace DotNetCore.CAP.MySql
                 return;
             }
 
-            var sql = CreateDbTablesScript(_options.Value.TableNamePrefix);
+            var sql = CreateDbTablesScript(_options.Value.DatabaseName, _options.Value.TableNamePrefix);
             using (var connection = new MySqlConnection(_options.Value.ConnectionString))
             {
                 await connection.ExecuteAsync(sql);
@@ -56,11 +56,11 @@ namespace DotNetCore.CAP.MySql
             _logger.LogDebug("Ensuring all create database tables script are applied.");
         }
 
-        protected virtual string CreateDbTablesScript(string prefix)
+        protected virtual string CreateDbTablesScript(string databaseName, string prefix)
         {
             var batchSql =
                 $@"
-CREATE TABLE IF NOT EXISTS `{prefix}.received` (
+CREATE TABLE IF NOT EXISTS `{databaseName}`.`{prefix}.received` (
   `Id` bigint NOT NULL,
   `Version` varchar(20) DEFAULT NULL,
   `Name` varchar(400) NOT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `{prefix}.received` (
   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS `{prefix}.published` (
+CREATE TABLE IF NOT EXISTS `{databaseName}`.`{prefix}.published` (
   `Id` bigint NOT NULL,
   `Version` varchar(20) DEFAULT NULL,
   `Name` varchar(200) NOT NULL,

--- a/src/DotNetCore.CAP.MySql/IStorageTransaction.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorageTransaction.MySql.cs
@@ -15,11 +15,13 @@ namespace DotNetCore.CAP.MySql
         private readonly IDbConnection _dbConnection;
 
         private readonly string _prefix;
+        private readonly string _databaseName;
 
         public MySqlStorageTransaction(MySqlStorageConnection connection)
         {
             var options = connection.Options;
             _prefix = options.TableNamePrefix;
+            _databaseName = options.DatabaseName;
 
             _dbConnection = new MySqlConnection(options.ConnectionString);
         }
@@ -32,7 +34,7 @@ namespace DotNetCore.CAP.MySql
             }
 
             var sql =
-                $"UPDATE `{_prefix}.published` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
+                $"UPDATE `{_databaseName}`.`{_prefix}.published` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
             _dbConnection.Execute(sql, message);
         }
 
@@ -44,7 +46,7 @@ namespace DotNetCore.CAP.MySql
             }
 
             var sql =
-                $"UPDATE `{_prefix}.received` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
+                $"UPDATE `{_databaseName}`.`{_prefix}.received` SET `Retries` = @Retries,`Content`= @Content,`ExpiresAt` = @ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
             _dbConnection.Execute(sql, message);
         }
 


### PR DESCRIPTION
业务数据库与CAP数据库不是同一个的时候，在事务中会有问题。
虽然强烈建议将CAP的表建在业务主库里面，但是有些外围的模块如果数据量与并发都不是很大的情况下，很有可能是分库的。这时事务的连接是其它库，CAP写入数据会报错，因为数据库没对。
修正了下，聊胜于无。
最后再说一遍，最好在一个库中，否则牵扯到了分布式事务，性能会有损耗。