### PR TITLE
Add capability to optionally set kafka message key via new header

### DIFF
--- a/src/DotNetCore.CAP.Kafka/ITransport.Kafka.cs
+++ b/src/DotNetCore.CAP.Kafka/ITransport.Kafka.cs
@@ -43,7 +43,7 @@ namespace DotNetCore.CAP.Kafka
                 var result = await producer.ProduceAsync(message.GetName(), new Message<string, byte[]>
                 {
                     Headers = headers,
-                    Key = message.GetId(),
+                    Key = message.Headers.TryGetValue(KafkaHeaders.KafkaKey, out string kafkaMessageKey) && !string.IsNullOrEmpty(kafkaMessageKey) ? kafkaMessageKey : message.GetId(),
                     Value = message.Body
                 });
 

--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -62,6 +62,8 @@ namespace DotNetCore.CAP.Kafka
                 }
                 headers.Add(Messages.Headers.Group, _groupId);
 
+                headers.Add(KafkaHeaders.KafkaKey, consumerResult.Key);
+
                 if (_kafkaOptions.CustomHeaders != null)
                 {
                     var customHeaders = _kafkaOptions.CustomHeaders(consumerResult);

--- a/src/DotNetCore.CAP.Kafka/KafkaHeaders.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaHeaders.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace DotNetCore.CAP.Kafka
+{
+    public static class KafkaHeaders
+    {
+        public const string KafkaKey = "cap-kafka-key";
+    }
+}


### PR DESCRIPTION
We need the ability to set the message key of Kafka messages sent via CAP. I've implemented this as an option here in a _far_ less invasive way than in #397.

If you add the `KafkaHeaders.KafkaKey` header, it will use the value as the Kafka message key. Otherwise the behavior will be as before.