### PR TITLE
Add a group prefix

### DIFF
--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -24,6 +24,7 @@ namespace DotNetCore.CAP
             Extensions = new List<ICapOptionsExtension>();
             Version = "v1";
             DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly()?.GetName().Name.ToLower();
+            GroupPrefix = "";
         }
 
         internal IList<ICapOptionsExtension> Extensions { get; }
@@ -32,6 +33,11 @@ namespace DotNetCore.CAP
         /// Subscriber default group name. kafka-->group name. rabbitmq --> queue name.
         /// </summary>
         public string DefaultGroup { get; set; }
+
+        /// <summary>
+        /// Subscriber to groups of prefixes
+        /// </summary>
+        public string GroupPrefix { get; set; }
 
         /// <summary>
         /// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20

--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -153,6 +153,11 @@ namespace DotNetCore.CAP.Internal
             {
                 attribute.Group = attribute.Group + "." + _capOptions.Version;
             }
+            
+            if (!string.IsNullOrEmpty(_capOptions.GroupPrefix))
+            {
+                attribute.Group = _capOptions.GroupPrefix + "." + attribute.Group;
+            }
         }
 
         private static ConsumerExecutorDescriptor InitDescriptor(

--- a/test/DotNetCore.CAP.Test/CustomConsumerSubscribeTest.cs
+++ b/test/DotNetCore.CAP.Test/CustomConsumerSubscribeTest.cs
@@ -56,7 +56,8 @@ namespace DotNetCore.CAP.Test
             _capOptions = serviceProvider.GetService<IOptions<CapOptions>>().Value;
         }
 
-        protected override IEnumerable<ConsumerExecutorDescriptor> FindConsumersFromInterfaceTypes(IServiceProvider provider)
+        protected override IEnumerable<ConsumerExecutorDescriptor> FindConsumersFromInterfaceTypes(
+            IServiceProvider provider)
         {
             var executorDescriptorList = new List<ConsumerExecutorDescriptor>();
 
@@ -102,6 +103,11 @@ namespace DotNetCore.CAP.Test
                         attr.Group = attr.Group + "." + _capOptions.Version;
                     }
 
+                    if (!string.IsNullOrEmpty(_capOptions.GroupPrefix))
+                    {
+                        attr.Group = _capOptions.GroupPrefix + "." + attr.Group;
+                    }
+
                     yield return new ConsumerExecutorDescriptor
                     {
                         Attribute = new CapSubscribeAttribute(attr.Name)
@@ -116,7 +122,9 @@ namespace DotNetCore.CAP.Test
         }
     }
 
-    public interface IMySubscribe { }
+    public interface IMySubscribe
+    {
+    }
 
     public class MySubscribeAttribute : Attribute
     {


### PR DESCRIPTION
        With the expansion of the project, after the basic function is extracted, the same service may need to subscribe to a message queue and specify to complete a certain function. Because the basic service is extracted into the basic package storage, the group name in the subscribed message queue Must be constants. It is convenient to complete the respective management by setting the prefix of the message queue of the service.
        Of course, the above are just examples for the problems I have encountered. Of course, you can add special expressions to the message queue routing by setting a prefix to achieve the same effect as Redis Prefix. If this function does not work for you, you can not set GroupPrefix, the last Group is the same as before,。
         I hope to pass the review, thank you very much