### PR TITLE
Removes line that added the kafka key to headers an extra time.

### DIFF
--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -62,8 +62,6 @@ namespace DotNetCore.CAP.Kafka
                 }
                 headers.Add(Messages.Headers.Group, _groupId);
 
-                headers.Add(KafkaHeaders.KafkaKey, consumerResult.Key);
-
                 if (_kafkaOptions.CustomHeaders != null)
                 {
                     var customHeaders = _kafkaOptions.CustomHeaders(consumerResult);


### PR DESCRIPTION
This caused any messages published by CAP with a kafka key set to not be consumable by CAP.