### PR TITLE
设置消费者最大执行时间，默认最大为5分钟，防止消费者死循环或时间超时导致消息堵塞

### DIFF
--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -21,6 +21,7 @@ namespace DotNetCore.CAP
             FailedRetryInterval = 60;
             FailedRetryCount = 50;
             ConsumerThreadCount = 1;
+            ConsumerMaxTimeOut = 300;
             Extensions = new List<ICapOptionsExtension>();
             Version = "v1";
             DefaultGroup = "cap.queue." + Assembly.GetEntryAssembly()?.GetName().Name.ToLower();
@@ -66,6 +67,12 @@ namespace DotNetCore.CAP
         /// Default is 1
         /// </summary>
         public int ConsumerThreadCount { get; set; }
+        
+        /// <summary>
+        /// consumer maximum execution time
+        /// Default is 300s
+        /// </summary>
+        public int ConsumerMaxTimeOut { get; set; }
 
         /// <summary>
         /// Registers an extension that will be executed when building services.

--- a/src/DotNetCore.CAP/Internal/Helper.cs
+++ b/src/DotNetCore.CAP/Internal/Helper.cs
@@ -4,6 +4,9 @@
 using System;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetCore.CAP.Internal
 {
@@ -14,7 +17,7 @@ namespace DotNetCore.CAP.Internal
         public static long ToTimestamp(DateTime value)
         {
             var elapsedTime = value - Epoch;
-            return (long)elapsedTime.TotalSeconds;
+            return (long) elapsedTime.TotalSeconds;
         }
 
         public static bool IsController(TypeInfo typeInfo)
@@ -62,6 +65,7 @@ namespace DotNetCore.CAP.Internal
             isInnerIp = IsInner(ipNum, aBegin, aEnd) || IsInner(ipNum, bBegin, bEnd) || IsInner(ipNum, cBegin, cEnd);
             return isInnerIp;
         }
+
         private static long GetIpNum(string ipAddress)
         {
             var ip = ipAddress.Split('.');
@@ -96,6 +100,128 @@ namespace DotNetCore.CAP.Internal
                    type == typeof(DateTimeOffset) ||
                    type == typeof(TimeSpan) ||
                    type == typeof(Uri);
+        }
+
+        public static async Task<TResult> TimeOutExecuteAsync<TResult>(
+            int seconds,
+            Func<CancellationToken, Task<TResult>> action)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            Func<TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___) => Task.FromResult(true);
+            return await TimeOutExecuteAsync(TimeSpan.FromSeconds(seconds), action, CancellationToken.None,
+                doNothingAsync, false);
+        }
+
+        public static TResult TimeOutExecute<TResult>(
+            int seconds,
+            Func<CancellationToken, TResult> action)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            Action<TimeSpan, Task, Exception> doNothingAsync = (_, __, ___) => { };
+            return TimeOutExecute(TimeSpan.FromSeconds(seconds), action, CancellationToken.None,
+                doNothingAsync);
+        }
+
+        public static async Task<TResult> TimeOutExecuteAsync<TResult>(
+            TimeSpan timeout,
+            Func<CancellationToken, Task<TResult>> action,
+            CancellationToken cancellationToken,
+            Func<TimeSpan, Task, Exception, Task> onTimeoutAsync,
+            bool continueOnCapturedContext)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (CancellationTokenSource timeoutCancellationTokenSource = new CancellationTokenSource())
+            {
+                using (CancellationTokenSource combinedTokenSource =
+                    CancellationTokenSource.CreateLinkedTokenSource(cancellationToken,
+                        timeoutCancellationTokenSource.Token))
+                {
+                    Task<TResult> actionTask = null;
+                    CancellationToken combinedToken = combinedTokenSource.Token;
+                    try
+                    {
+                        Task<TResult> timeoutTask = AsTask<TResult>(timeoutCancellationTokenSource.Token);
+                        timeoutCancellationTokenSource.CancelAfter(timeout);
+                        actionTask = action(combinedToken);
+                        return await (await Task.WhenAny(actionTask, timeoutTask)
+                            .ConfigureAwait(continueOnCapturedContext)).ConfigureAwait(continueOnCapturedContext);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
+                        {
+                            await onTimeoutAsync(timeout, actionTask, ex)
+                                .ConfigureAwait(continueOnCapturedContext);
+                            throw new TimeoutException(
+                                "The executed delegate did not complete in the timeout. Check whether there is a dead loop or a time-consuming operation in the delegate",
+                                ex);
+                        }
+
+                        throw;
+                    }
+                }
+            }
+        }
+
+        public static TResult TimeOutExecute<TResult>(
+            TimeSpan timeout,
+            Func<CancellationToken, TResult> action,
+            CancellationToken cancellationToken,
+            Action<TimeSpan, Task, Exception> onTimeout)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (CancellationTokenSource timeoutCancellationTokenSource = new CancellationTokenSource())
+            {
+                using (CancellationTokenSource combinedTokenSource =
+                    CancellationTokenSource.CreateLinkedTokenSource(cancellationToken,
+                        timeoutCancellationTokenSource.Token))
+                {
+                    CancellationToken combinedToken = combinedTokenSource.Token;
+
+                    Task<TResult> actionTask = null;
+                    try
+                    {
+                        timeoutCancellationTokenSource.CancelAfter(timeout);
+                        actionTask = Task.Run(() =>
+                                action(
+                                    combinedToken) // cancellation token here allows the user delegate to react to cancellation: possibly clear up; then throw an OperationCanceledException.
+                            , combinedToken); // cancellation token here only allows Task.Run() to not begin the passed delegate at all, if cancellation occurs prior to invoking the delegate.
+                        try
+                        {
+                            actionTask.Wait(timeoutCancellationTokenSource
+                                .Token); // cancellation token here cancels the Wait() and causes it to throw, but does not cancel actionTask.  We use only timeoutCancellationTokenSource.Token here, not combinedToken.  If we allowed the user's cancellation token to cancel the Wait(), in this pessimistic scenario where the user delegate may not observe that cancellation, that would create a no-longer-observed task.  That task could in turn later fault before completing, risking an UnobservedTaskException.
+                        }
+                        catch (AggregateException ex) when (ex.InnerExceptions.Count == 1
+                        ) // Issue #270.  Unwrap extra AggregateException caused by the way pessimistic timeout policy for synchronous executions is necessarily constructed.
+                        {
+                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        }
+
+                        return actionTask.Result;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Note that we cannot rely on testing (operationCanceledException.CancellationToken == combinedToken || operationCanceledException.CancellationToken == timeoutCancellationTokenSource.Token)
+                        // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
+                        if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
+                        {
+                            onTimeout(timeout, actionTask, ex);
+                            throw new TimeoutException(
+                                "The executed delegate did not complete in the timeout. Check whether there is a dead loop or a time-consuming operation in the delegate", ex);
+                        }
+
+                        throw;
+                    }
+                }
+            }
+        }
+
+        public static Task<TResult> AsTask<TResult>(CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<TResult>();
+            cancellationToken.Register(() => { tcs.TrySetCanceled(); },
+                useSynchronizationContext: false);
+            return tcs.Task;
         }
     }
 }


### PR DESCRIPTION
设置消费者执行所需要的最大执行时间，默认为5分钟

开发中经常遇到有小伙伴写死循环的代码，而消息对列中如果存在死循环，会导致消费者消息长期处于Scheduled状态，并且因为没有任何的提示信息，导致开发者在排查问题的时候很难定位，甚至怀疑是cap的问题，此次修改后，如果执行时间超时会标记为Failed，并记录原因为：The executed delegate did not complete in the timeout. Check whether there is a dead loop or a time-consuming operation in the delegate，协助开发者定位错误