### PR TITLE
add exchange type in consumer to support the delayed message

### DIFF
--- a/samples/Sample.ConsoleApp/EventSubscriber.cs
+++ b/samples/Sample.ConsoleApp/EventSubscriber.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using DotNetCore.CAP;
+﻿using DotNetCore.CAP;
+using System;
 
 namespace Sample.ConsoleApp
 {
@@ -9,6 +9,17 @@ namespace Sample.ConsoleApp
         public void ShowTime(DateTime date)
         {
             Console.WriteLine(date);
+        }
+
+        /// <summary>
+        /// 延迟队列消费端
+        /// </summary>
+        /// <param name="senttime">发送时间</param>
+        [CapSubscribe("rk.delayed", Group = "queue.delayed.net")]
+        public void ShowTime(string senttime)
+        {
+            Console.WriteLine($"process time: {senttime}");
+            Console.WriteLine($"current time: {DateTime.Now}");
         }
     }
 }

--- a/samples/Sample.ConsoleApp/Program.cs
+++ b/samples/Sample.ConsoleApp/Program.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using DotNetCore.CAP.Internal;
+﻿using DotNetCore.CAP.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Sample.ConsoleApp
 {
@@ -14,6 +14,7 @@ namespace Sample.ConsoleApp
             container.AddLogging(x => x.AddConsole());
             container.AddCap(x =>
             {
+                /*
                 //console app does not support dashboard
 
                 x.UseMySql("Server=192.168.3.57;Port=3307;Database=captest;Uid=root;Pwd=123123;");
@@ -22,6 +23,23 @@ namespace Sample.ConsoleApp
                     z.HostName = "192.168.3.57";
                     z.UserName = "user";
                     z.Password = "wJ0p5gSs17";
+                    // z.ExChangeType = "x-delayed-message"; // 延迟队列
+                });
+                */
+
+                //如果你使用的ADO.NET，根据数据库选择进行配置：
+                x.UseMySql("Server=192.168.16.150;Port=3306;Database=order;Uid=uid;Pwd=pwd;Charset=utf8mb4");
+
+                //CAP支持 RabbitMQ、Kafka、AzureServiceBus 等作为MQ，根据使用选择配置：
+                x.UseRabbitMQ(cfg =>
+                {
+                    cfg.HostName = "192.168.16.150";
+                    cfg.VirtualHost = "dev";
+                    cfg.Port = 5672;
+                    cfg.UserName = "dev";
+                    cfg.Password = "password";
+                    cfg.ExchangeName = "ex.delayed.message";
+                    cfg.ExChangeType = "x-delayed-message"; // 延迟队列
                 });
             });
 

--- a/samples/Sample.RabbitMQ.MySql/Controllers/ValuesController.cs
+++ b/samples/Sample.RabbitMQ.MySql/Controllers/ValuesController.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.Data;
-using System.Threading.Tasks;
-using Dapper;
+﻿using Dapper;
 using DotNetCore.CAP;
 using Microsoft.AspNetCore.Mvc;
 using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
 
 namespace Sample.RabbitMQ.MySql.Controllers
 {
@@ -16,6 +17,23 @@ namespace Sample.RabbitMQ.MySql.Controllers
         public ValuesController(ICapPublisher capPublisher)
         {
             _capBus = capPublisher;
+        }
+
+        /// <summary>
+        /// 延迟队列
+        /// </summary>
+        /// <returns>ok</returns>
+        [HttpGet("delaymq")]
+        public async Task<IActionResult> DelayMq()
+        {
+            var msg = $"this is a delayed message,current date: {DateTime.Now}";
+            var headers = new Dictionary<string, string>
+            {
+                { "x-delay", "6000" } // 6000ms = 6s
+            };
+            await _capBus.PublishAsync("rk.delayed", msg, headers);
+
+            return Ok();
         }
 
         [Route("~/without/transaction")]

--- a/samples/Sample.RabbitMQ.MySql/Startup.cs
+++ b/samples/Sample.RabbitMQ.MySql/Startup.cs
@@ -1,7 +1,5 @@
-﻿using DotNetCore.CAP.Messages;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Sample.RabbitMQ.MySql
 {
@@ -13,6 +11,7 @@ namespace Sample.RabbitMQ.MySql
 
             services.AddCap(x =>
             {
+                /*
                 x.UseEntityFramework<AppDbContext>();
                 x.UseRabbitMQ("localhost");
                 x.UseDashboard();
@@ -20,9 +19,25 @@ namespace Sample.RabbitMQ.MySql
                 x.FailedThresholdCallback = failed =>
                 {
                     var logger = failed.ServiceProvider.GetService<ILogger<Startup>>();
-                    logger.LogError($@"A message of type {failed.MessageType} failed after executing {x.FailedRetryCount} several times, 
+                    logger.LogError($@"A message of type {failed.MessageType} failed after executing {x.FailedRetryCount} several times,
                         requiring manual troubleshooting. Message name: {failed.Message.GetName()}");
                 };
+                */
+
+                //如果你使用的ADO.NET，根据数据库选择进行配置：
+                x.UseMySql("Server=192.168.16.150;Port=3306;Database=order;Uid=uid;Pwd=pwd;Charset=utf8mb4");
+
+                //CAP支持 RabbitMQ、Kafka、AzureServiceBus 等作为MQ，根据使用选择配置：
+                x.UseRabbitMQ(cfg =>
+                {
+                    cfg.HostName = "192.168.16.150";
+                    cfg.VirtualHost = "dev";
+                    cfg.Port = 5672;
+                    cfg.UserName = "dev";
+                    cfg.Password = "password";
+                    cfg.ExchangeName = "ex.delayed.message";
+                    cfg.ExChangeType = "x-delayed-message"; // 延迟队列
+                });
             });
 
             services.AddControllers();

--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -3,8 +3,8 @@
 
 // ReSharper disable once CheckNamespace
 
-using System;
 using RabbitMQ.Client;
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP
@@ -35,7 +35,7 @@ namespace DotNetCore.CAP
         public const string DefaultExchangeName = "cap.default.router";
 
         /// <summary> The topic exchange type. </summary>
-        public const string ExchangeType = "topic";
+        public const string DefaultExchangeType = "topic";
 
         /// <summary>
         /// The host to connect to.
@@ -62,6 +62,11 @@ namespace DotNetCore.CAP
         /// Topic exchange name when declare a topic exchange.
         /// </summary>
         public string ExchangeName { get; set; } = DefaultExchangeName;
+
+        /// <summary>
+        /// Exchange yype where declare an exchange
+        /// </summary>
+        public string ExChangeType { get; set; } = DefaultExchangeType;
 
         /// <summary>
         /// The port to connect on.

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Transport;
 using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
 using Headers = DotNetCore.CAP.Messages.Headers;
 
 namespace DotNetCore.CAP.RabbitMQ
@@ -20,6 +20,7 @@ namespace DotNetCore.CAP.RabbitMQ
 
         private readonly IConnectionChannelPool _connectionChannelPool;
         private readonly string _exchangeName;
+        private readonly string _exchangeType;
         private readonly string _queueName;
         private readonly RabbitMQOptions _rabbitMQOptions;
         private IModel _channel;
@@ -34,6 +35,7 @@ namespace DotNetCore.CAP.RabbitMQ
             _connectionChannelPool = connectionChannelPool;
             _rabbitMQOptions = options.Value;
             _exchangeName = connectionChannelPool.Exchange;
+            _exchangeType = _rabbitMQOptions.ExChangeType;
         }
 
         public event EventHandler<TransportMessage> OnMessageReceived;
@@ -112,7 +114,7 @@ namespace DotNetCore.CAP.RabbitMQ
 
                     _channel = _connection.CreateModel();
 
-                    _channel.ExchangeDeclare(_exchangeName, RabbitMQOptions.ExchangeType, true);
+                    _channel.ExchangeDeclare(_exchangeName, _exchangeType, true);
 
                     var arguments = new Dictionary<string, object>
                     {
@@ -184,6 +186,6 @@ namespace DotNetCore.CAP.RabbitMQ
             OnLog?.Invoke(sender, args);
         }
 
-        #endregion
+        #endregion events
     }
 }


### PR DESCRIPTION
### Feature: 
To support delayed rabbitmq messages, can extend Exchange Type to be configurable #401 

Pls see the commit logs,  I amend `RabbitMQOptions` to make `ExchangeType` as a settable property.
Then I tested in samples by sending out some delayed messages and received by consumer client. Also I start up one similar [java consumer client](https://www.jianshu.com/p/3bd861c4b479)。They have same delayed behavior as below.

### Test Result:
![image](https://user-images.githubusercontent.com/37995141/83400923-4faabc00-a436-11ea-8cc7-35e3b163a9bb.png)

### Mysql records:
Publish:
{"Headers":{"x-delay":"6000","cap-msg-id":"1267395401949954048","cap-msg-name":"rk.delayed","cap-msg-type":"String","cap-senttime":"2020/6/1 17:59:45 +08:00","cap-corr-id":"1267395401949954048","cap-corr-seq":"0"},"Value":"this is a delayed message,current date: 2020/6/1 17:59:45"}

Consumer:
{"Headers":{"x-delay":"6000","cap-msg-id":"1267395401949954048","cap-msg-name":"rk.delayed","cap-msg-type":"String","cap-senttime":"2020/6/1 17:59:45 +08:00","cap-corr-id":"1267395401949954048","cap-corr-seq":"0","cap-msg-group":"queue.delayed.net.v1"},"Value":"this is a delayed message,current date: 2020/6/1 17:59:45"}
