### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/samples/Sample.RabbitMQ.MySql/Controllers/ValuesController.cs
+++ b/samples/Sample.RabbitMQ.MySql/Controllers/ValuesController.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Dapper;
 using DotNetCore.CAP;
 using Microsoft.AspNetCore.Mvc;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Sample.RabbitMQ.MySql.Controllers
 {

--- a/src/DotNetCore.CAP.MySql/DotNetCore.CAP.MySql.csproj
+++ b/src/DotNetCore.CAP.MySql/DotNetCore.CAP.MySql.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.5" />
-    <PackageReference Include="MySqlConnector" Version="0.69.1" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
@@ -13,7 +13,7 @@ using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DotNetCore.CAP.MySql
 {

--- a/src/DotNetCore.CAP.MySql/IMonitoringApi.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IMonitoringApi.MySql.cs
@@ -10,7 +10,7 @@ using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
 using DotNetCore.CAP.Persistence;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DotNetCore.CAP.MySql
 {

--- a/src/DotNetCore.CAP.MySql/IStorageInitializer.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorageInitializer.MySql.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DotNetCore.CAP.MySql
 {

--- a/test/DotNetCore.CAP.MySql.Test/ConnectionUtil.cs
+++ b/test/DotNetCore.CAP.MySql.Test/ConnectionUtil.cs
@@ -1,5 +1,5 @@
 using System;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DotNetCore.CAP.MySql.Test
 {


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.