### PR TITLE
增加额外可配参数，以支持通过队列分发到各自的消费者

### DIFF
--- a/samples/Sample.RabbitMQ.SqlServer/appsettings.json
+++ b/samples/Sample.RabbitMQ.SqlServer/appsettings.json
@@ -4,5 +4,8 @@
     "LogLevel": {
       "Default": "Error"
     }
+  },
+  "AppSettings": {
+    "ClientId": ""
   }
 }

--- a/src/DotNetCore.CAP/DotNetCore.CAP.csproj
+++ b/src/DotNetCore.CAP/DotNetCore.CAP.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/DotNetCore.CAP/Internal/Helper.cs
+++ b/src/DotNetCore.CAP/Internal/Helper.cs
@@ -4,13 +4,21 @@
 using System;
 using System.ComponentModel;
 using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 
 namespace DotNetCore.CAP.Internal
 {
     public static class Helper
     {
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Local);
-
+        public static IConfiguration Configuration { get; set; }
+        static Helper()
+        {
+            Configuration = new ConfigurationBuilder()
+                .Add(new JsonConfigurationSource { Path = "appsettings.json", ReloadOnChange = true })
+                .Build();
+        }
         public static long ToTimestamp(DateTime value)
         {
             var elapsedTime = value - Epoch;
@@ -97,5 +105,6 @@ namespace DotNetCore.CAP.Internal
                    type == typeof(TimeSpan) ||
                    type == typeof(Uri);
         }
+
     }
 }

--- a/src/DotNetCore.CAP/Internal/Helper.cs
+++ b/src/DotNetCore.CAP/Internal/Helper.cs
@@ -12,13 +12,16 @@ namespace DotNetCore.CAP.Internal
     public static class Helper
     {
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
         public static IConfiguration Configuration { get; set; }
+
         static Helper()
         {
             Configuration = new ConfigurationBuilder()
                 .Add(new JsonConfigurationSource { Path = "appsettings.json", ReloadOnChange = true })
                 .Build();
         }
+
         public static long ToTimestamp(DateTime value)
         {
             var elapsedTime = value - Epoch;
@@ -105,6 +108,5 @@ namespace DotNetCore.CAP.Internal
                    type == typeof(TimeSpan) ||
                    type == typeof(Uri);
         }
-
     }
 }

--- a/src/DotNetCore.CAP/Internal/TopicAttribute.cs
+++ b/src/DotNetCore.CAP/Internal/TopicAttribute.cs
@@ -14,13 +14,25 @@ namespace DotNetCore.CAP.Internal
     {
         protected TopicAttribute(string name)
         {
-            Name = name;
+            if (string.IsNullOrEmpty(_clientId))
+            {
+                Name = name;
+            }
+            else
+            {
+                Name = name + "."+_clientId;
+            }
         }
 
         /// <summary>
         /// Topic or exchange route key name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Other parameter like clientId,customerId, .... from setting 
+        /// </summary>
+        private readonly string _clientId= Helper.Configuration["AppSettings:ClientId"];
 
         /// <summary>
         /// Default group name is CapOptions setting.(Assembly name)


### PR DESCRIPTION
场景：
需要根据不同客户设置业务队列，有数据变化则将数据放入对应的客户队列中，
客户服务器环境监听所属队列 消费消息

原因：
目前由于 Attribute 设置Topic 或者 exchange route key name 的时候不能根据配置加入额外的标识


谢谢