### PR TITLE
partial topic attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,21 @@ public void ConfigureServices(IServiceCollection services)
     });
 }
 ```
+#### Use partials for topic subscriptions
+
+To group topic subscriptions on class level you're able to define a subscription on a method as a partial. Subscriptions on the message queue will then be a combination of the topic defined on the class and the topic defined on the method. In the following example the `Create(..)` function will be invoked when receiving a message on `customers.create`
+
+```c#
+[CapSubscribe("customers")]
+public class CustomersSubscriberService : ICapSubscribe
+{
+    [CapSubscribe("create", isPartial: true)]
+    public void Create(Customer customer)
+    {
+    }
+}
+```
+
 
 #### Subscribe Group
 

--- a/src/DotNetCore.CAP.Dashboard/Pages/SubscriberPage.cshtml
+++ b/src/DotNetCore.CAP.Dashboard/Pages/SubscriberPage.cshtml
@@ -45,7 +45,7 @@
                                 {
                                     <td rowspan="@rowCount">@subscriber.Key</td>
                                 }
-                                <td>@column.Attribute.Name</td>
+                                <td>@column.TopicName</td>
                                 <td>
                                     <span style="color: #00bcd4">@column.ImplTypeInfo.Name</span>：
                                     <div class="job-snippet-code">

--- a/src/DotNetCore.CAP.Dashboard/Pages/SubscriberPage.generated.cs
+++ b/src/DotNetCore.CAP.Dashboard/Pages/SubscriberPage.generated.cs
@@ -200,7 +200,7 @@ WriteLiteral("                                <td>");
 
             
             #line 48 "..\..\Pages\SubscriberPage.cshtml"
-                               Write(column.Attribute.Name);
+                               Write(column.TopicName);
 
             
             #line default

--- a/src/DotNetCore.CAP/CAP.Attribute.cs
+++ b/src/DotNetCore.CAP/CAP.Attribute.cs
@@ -11,8 +11,8 @@ namespace DotNetCore.CAP
 {
     public class CapSubscribeAttribute : TopicAttribute
     {
-        public CapSubscribeAttribute(string name)
-            : base(name)
+        public CapSubscribeAttribute(string name, bool isPartial = false)
+            : base(name, isPartial)
         {
 
         }

--- a/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
+++ b/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
@@ -24,6 +24,7 @@ namespace DotNetCore.CAP.Internal
 
         public IList<ParameterDescriptor> Parameters { get; set; }
 
+        private string _topicName;
         /// <summary>
         /// Topic name based on both <see cref="Attribute"/> and <see cref="ClassAttribute"/>.
         /// </summary>
@@ -31,15 +32,19 @@ namespace DotNetCore.CAP.Internal
         {
             get
             {
-                if (ClassAttribute != null && Attribute.IsPartial)
+                if (_topicName == null) 
                 {
-                    // Allows class level attribute name to end with a '.' and allows methods level attribute to start with a '.'.
-                    return string.Join(".", $"{ClassAttribute.Name}.{Attribute.Name}".Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
+                    if (ClassAttribute != null && Attribute.IsPartial)
+                    {
+                        // Allows class level attribute name to end with a '.' and allows methods level attribute to start with a '.'.
+                        _topicName = $"{ClassAttribute.Name.TrimEnd('.')}.{Attribute.Name.TrimStart('.')}";
+                    }
+                    else
+                    {
+                        _topicName = Attribute.Name;
+                    }
                 }
-                else
-                {
-                    return Attribute.Name;
-                }
+                return _topicName;
             }
         }
     }

--- a/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
+++ b/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
@@ -20,7 +20,28 @@ namespace DotNetCore.CAP.Internal
 
         public TopicAttribute Attribute { get; set; }
 
+        public TopicAttribute ClassAttribute { get; set; }
+
         public IList<ParameterDescriptor> Parameters { get; set; }
+
+        /// <summary>
+        /// Topic name based on both <see cref="Attribute"/> and <see cref="ClassAttribute"/>.
+        /// </summary>
+        public string TopicName
+        {
+            get
+            {
+                if (ClassAttribute != null && Attribute.IsPartial)
+                {
+                    // Allows class level attribute name to end with a '.' and allows methods level attribute to start with a '.'.
+                    return string.Join(".", $"{ClassAttribute.Name}.{Attribute.Name}".Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+                else
+                {
+                    return Attribute.Name;
+                }
+            }
+        }
     }
 
     public class ParameterDescriptor

--- a/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
@@ -79,7 +79,7 @@ namespace DotNetCore.CAP.Internal
 
                                 RegisterMessageProcessor(client);
 
-                                client.Subscribe(matchGroup.Value.Select(x => x.Attribute.Name));
+                                client.Subscribe(matchGroup.Value.Select(x => x.TopicName));
 
                                 client.Listening(_pollingDelay, _cts.Token);
                             }

--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -116,17 +116,24 @@ namespace DotNetCore.CAP.Internal
 
         protected IEnumerable<ConsumerExecutorDescriptor> GetTopicAttributesDescription(TypeInfo typeInfo, TypeInfo serviceTypeInfo = null)
         {
+            var topicClassAttribute = typeInfo.GetCustomAttribute<TopicAttribute>(true);
+
             foreach (var method in typeInfo.DeclaredMethods)
             {
-                var topicAttr = method.GetCustomAttributes<TopicAttribute>(true);
-                var topicAttributes = topicAttr as IList<TopicAttribute> ?? topicAttr.ToList();
+                var topicMethodAttributes = method.GetCustomAttributes<TopicAttribute>(true);
 
-                if (!topicAttributes.Any())
+                // Ignore partial attributes when no topic attribute is defined on class.
+                if (topicClassAttribute == null) 
+                {
+                    topicMethodAttributes = topicMethodAttributes.Where(x => x.IsPartial);
+                }
+
+                if (!topicMethodAttributes.Any())
                 {
                     continue;
                 }
 
-                foreach (var attr in topicAttributes)
+                foreach (var attr in topicMethodAttributes)
                 {
                     SetSubscribeAttribute(attr);
 
@@ -138,21 +145,14 @@ namespace DotNetCore.CAP.Internal
                             IsFromCap = parameter.GetCustomAttributes(typeof(FromCapAttribute)).Any()
                         }).ToList();
 
-                    yield return InitDescriptor(attr, method, typeInfo, serviceTypeInfo, parameters);
+                    yield return InitDescriptor(attr, method, typeInfo, serviceTypeInfo, parameters, topicClassAttribute);
                 }
             }
         }
 
         protected virtual void SetSubscribeAttribute(TopicAttribute attribute)
         {
-            if (attribute.Group == null)
-            {
-                attribute.Group = _capOptions.DefaultGroup + "." + _capOptions.Version;
-            }
-            else
-            {
-                attribute.Group = attribute.Group + "." + _capOptions.Version;
-            }
+            attribute.Group = (attribute.Group ?? _capOptions.DefaultGroup) + "." + _capOptions.Version;
         }
 
         private static ConsumerExecutorDescriptor InitDescriptor(
@@ -160,11 +160,13 @@ namespace DotNetCore.CAP.Internal
             MethodInfo methodInfo,
             TypeInfo implType,
             TypeInfo serviceTypeInfo,
-            IList<ParameterDescriptor> parameters)
+            IList<ParameterDescriptor> parameters,
+            TopicAttribute classAttr = null)
         {
             var descriptor = new ConsumerExecutorDescriptor
             {
                 Attribute = attr,
+                ClassAttribute = classAttr,
                 MethodInfo = methodInfo,
                 ImplTypeInfo = implType,
                 ServiceTypeInfo = serviceTypeInfo,
@@ -176,7 +178,7 @@ namespace DotNetCore.CAP.Internal
 
         private ConsumerExecutorDescriptor MatchUsingName(string key, IReadOnlyList<ConsumerExecutorDescriptor> executeDescriptor)
         {
-            return executeDescriptor.FirstOrDefault(x => x.Attribute.Name.Equals(key, StringComparison.InvariantCultureIgnoreCase));
+            return executeDescriptor.FirstOrDefault(x => x.TopicName.Equals(key, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private ConsumerExecutorDescriptor MatchAsteriskUsingRegex(string key, IReadOnlyList<ConsumerExecutorDescriptor> executeDescriptor)
@@ -184,10 +186,10 @@ namespace DotNetCore.CAP.Internal
             var group = executeDescriptor.First().Attribute.Group;
             if (!_asteriskList.TryGetValue(group, out var tmpList))
             {
-                tmpList = executeDescriptor.Where(x => x.Attribute.Name.IndexOf('*') >= 0)
+                tmpList = executeDescriptor.Where(x => x.TopicName.IndexOf('*') >= 0)
                     .Select(x => new RegexExecuteDescriptor<ConsumerExecutorDescriptor>
                     {
-                        Name = ("^" + x.Attribute.Name + "$").Replace("*", "[0-9_a-zA-Z]+").Replace(".", "\\."),
+                        Name = ("^" + x.TopicName + "$").Replace("*", "[0-9_a-zA-Z]+").Replace(".", "\\."),
                         Descriptor = x
                     }).ToList();
                 _asteriskList.TryAdd(group, tmpList);
@@ -210,10 +212,10 @@ namespace DotNetCore.CAP.Internal
             if (!_poundList.TryGetValue(group, out var tmpList))
             {
                 tmpList = executeDescriptor
-                    .Where(x => x.Attribute.Name.IndexOf('#') >= 0)
+                    .Where(x => x.TopicName.IndexOf('#') >= 0)
                     .Select(x => new RegexExecuteDescriptor<ConsumerExecutorDescriptor>
                     {
-                        Name = ("^" + x.Attribute.Name.Replace(".", "\\.") + "$").Replace("#", "[0-9_a-zA-Z\\.]+"),
+                        Name = ("^" + x.TopicName.Replace(".", "\\.") + "$").Replace("#", "[0-9_a-zA-Z\\.]+"),
                         Descriptor = x
                     }).ToList();
                 _poundList.TryAdd(group, tmpList);

--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -123,7 +123,7 @@ namespace DotNetCore.CAP.Internal
                 var topicMethodAttributes = method.GetCustomAttributes<TopicAttribute>(true);
 
                 // Ignore partial attributes when no topic attribute is defined on class.
-                if (topicClassAttribute == null) 
+                if (topicClassAttribute is null) 
                 {
                     topicMethodAttributes = topicMethodAttributes.Where(x => x.IsPartial);
                 }

--- a/src/DotNetCore.CAP/Internal/TopicAttribute.cs
+++ b/src/DotNetCore.CAP/Internal/TopicAttribute.cs
@@ -12,15 +12,23 @@ namespace DotNetCore.CAP.Internal
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
     public abstract class TopicAttribute : Attribute
     {
-        protected TopicAttribute(string name)
+        protected TopicAttribute(string name, bool isPartial = false)
         {
             Name = name;
+            IsPartial = isPartial;
         }
 
         /// <summary>
         /// Topic or exchange route key name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Defines wether this attribute defines a topic subscription partial.
+        /// The defined topic will be combined with a topic subscription defined on class level,
+        /// which results for example in subscription on "class.method".
+        /// </summary>
+        public bool IsPartial { get; }
 
         /// <summary>
         /// Default group name is CapOptions setting.(Assembly name)

--- a/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
+++ b/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
@@ -32,12 +32,15 @@ namespace DotNetCore.CAP.Test
             Assert.Equal(6, candidates.Count);
         }
 
-        [Fact]
-        public void CanFindSpecifiedTopic()
+        [Theory]
+        [InlineData("Candidates.Foo")]
+        [InlineData("Candidates.Foo3")]
+        [InlineData("Candidates.Foo4")]
+        public void CanFindSpecifiedTopic(string topic)
         {
             var selector = _provider.GetRequiredService<IConsumerServiceSelector>();
             var candidates = selector.SelectCandidates();
-            var bestCandidates = selector.SelectBestCandidate("Candidates.Foo", candidates);
+            var bestCandidates = selector.SelectBestCandidate(topic, candidates);
 
             Assert.NotNull(bestCandidates);
             Assert.NotNull(bestCandidates.MethodInfo);
@@ -116,7 +119,7 @@ namespace DotNetCore.CAP.Test
 
     public class CandidatesTopic : TopicAttribute
     {
-        public CandidatesTopic(string topicName) : base(topicName)
+        public CandidatesTopic(string topicName, bool isPartial = false) : base(topicName, isPartial)
         {
         }
     }
@@ -129,6 +132,7 @@ namespace DotNetCore.CAP.Test
     {
     }
 
+    [CandidatesTopic("Candidates")]
     public class CandidatesFooTest : IFooTest, ICapSubscribe
     {
         [CandidatesTopic("Candidates.Foo")]
@@ -142,6 +146,20 @@ namespace DotNetCore.CAP.Test
         public void GetFoo2()
         {
             Console.WriteLine("GetFoo2() method has bee excuted.");
+        }
+
+        [CandidatesTopic("Foo3", isPartial: true)]
+        public Task GetFoo3()
+        {
+            Console.WriteLine("GetFoo3() method has bee excuted.");
+            return Task.CompletedTask;
+        }
+
+        [CandidatesTopic(".Foo4", isPartial: true)]
+        public Task GetFoo4()
+        {
+            Console.WriteLine("GetFoo4() method has bee excuted.");
+            return Task.CompletedTask;
         }
 
         [CandidatesTopic("*.*.Asterisk")]

--- a/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
+++ b/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
@@ -29,7 +29,7 @@ namespace DotNetCore.CAP.Test
             var selector = _provider.GetRequiredService<IConsumerServiceSelector>();
             var candidates = selector.SelectCandidates();
 
-            Assert.Equal(6, candidates.Count);
+            Assert.Equal(8, candidates.Count);
         }
 
         [Theory]


### PR DESCRIPTION
Adds the functionality described in issue [#613](https://github.com/dotnetcore/CAP/issues/613)

Quoted from the updated `README.md`:
#### Use partials for topic subscriptions

To group topic subscriptions on class level you're able to define a subscription on a method as a partial. Subscriptions on the message queue will then be a combination of the topic defined on the class and the topic defined on the method. In the following example the `Create(..)` function will be invoked when receiving a message on `customers.create`

```c#
[CapSubscribe("customers")]
public class CustomersSubscriberService : ICapSubscribe
{
    [CapSubscribe("create", isPartial: true)]
    public void Create(Customer customer)
    {
    }
}
```