### PR TITLE
fixed #622 #624

### DIFF
--- a/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
@@ -108,8 +108,8 @@ namespace DotNetCore.CAP.PostgreSql
                     {
                         Id = reader.GetInt64(index++),
                         Version = reader.GetString(index++),
-                        Group = queryDto.MessageType == MessageType.Subscribe ? reader.GetString(index++) : default,
                         Name = reader.GetString(index++),
+                        Group = queryDto.MessageType == MessageType.Subscribe ? reader.GetString(index++) : default,
                         Content = reader.GetString(index++),
                         Retries = reader.GetInt32(index++),
                         Added = reader.GetDateTime(index++),

--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -125,7 +125,7 @@ namespace DotNetCore.CAP.Internal
                 // Ignore partial attributes when no topic attribute is defined on class.
                 if (topicClassAttribute is null) 
                 {
-                    topicMethodAttributes = topicMethodAttributes.Where(x => x.IsPartial);
+                    topicMethodAttributes = topicMethodAttributes.Where(x => !x.IsPartial);
                 }
 
                 if (!topicMethodAttributes.Any())


### PR DESCRIPTION
fixed@When class is not marked CapSubscribe, the method not marked isPartial cannot be found #622 

fixed@CAP dashborad received list display wrong cloumn when I use PostgreSql #624 