### PR TITLE
GetRuntimeMethods instead of DeclaredMethods to get inherited members.

### DIFF
--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -118,7 +118,7 @@ namespace DotNetCore.CAP.Internal
         {
             var topicClassAttribute = typeInfo.GetCustomAttribute<TopicAttribute>(true);
 
-            foreach (var method in typeInfo.DeclaredMethods)
+            foreach (var method in typeInfo.GetRuntimeMethods())
             {
                 var topicMethodAttributes = method.GetCustomAttributes<TopicAttribute>(true);
 

--- a/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
+++ b/test/DotNetCore.CAP.Test/ConsumerServiceSelectorTest.cs
@@ -30,7 +30,7 @@ namespace DotNetCore.CAP.Test
             var selector = _provider.GetRequiredService<IConsumerServiceSelector>();
             var candidates = selector.SelectCandidates();
 
-            Assert.Equal(9, candidates.Count);
+            Assert.Equal(10, candidates.Count);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #646