### PR TITLE
Support leader election for need retry

### DIFF
--- a/CAP.sln
+++ b/CAP.sln
@@ -67,6 +67,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.AmazonSQS", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.AmazonSQS.InMemory", "samples\Sample.AmazonSQS.InMemory\Sample.AmazonSQS.InMemory.csproj", "{B187DD15-092D-4B72-9807-50856607D237}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.LeaderElection", "src\DotNetCore.CAP.LeaderElection\DotNetCore.CAP.LeaderElection.csproj", "{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{B187DD15-092D-4B72-9807-50856607D237}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B187DD15-092D-4B72-9807-50856607D237}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B187DD15-092D-4B72-9807-50856607D237}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +184,7 @@ Global
 		{2B0F467E-ABBD-4A51-BF38-D4F609DB6266} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 		{43475E00-51B7-443D-BC2D-FC21F9D8A0B4} = {9B2AE124-6636-4DE9-83A3-70360DABD0C4}
 		{B187DD15-092D-4B72-9807-50856607D237} = {3A6B6931-A123-477A-9469-8B468B5385AF}
+		{4044A567-B4AB-46AD-AF1A-FBF49DAE4E44} = {9B2AE124-6636-4DE9-83A3-70360DABD0C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E70565D-94CF-40B4-BFE1-AC18D5F736AB}

--- a/src/DotNetCore.CAP.LeaderElection/CAP.LeaderElectionOptions.cs
+++ b/src/DotNetCore.CAP.LeaderElection/CAP.LeaderElectionOptions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotNetCore.CAP.LeaderElection
+{
+    public class LeaderElectionOptions
+    {
+        public const string DefaultServerHost = "localhost";
+        public const int DefaultServerPort = 8500;
+
+        public const string DefaultLockName = "cap.leaderelection.lock";
+
+        public LeaderElectionOptions()
+        {
+            ServerHostName = DefaultServerHost;
+            ServerPort = DefaultServerPort;
+
+            LockName = DefaultLockName;
+        }
+
+        public string ServerHostName { get; set; }
+        public int ServerPort { get; set; }
+        public string LockName { get; set; }
+    }
+}

--- a/src/DotNetCore.CAP.LeaderElection/CAP.LeaderElectionOptionsExtensions.cs
+++ b/src/DotNetCore.CAP.LeaderElection/CAP.LeaderElectionOptionsExtensions.cs
@@ -1,0 +1,46 @@
+﻿using DotNetCore.CAP.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace DotNetCore.CAP.LeaderElection
+{
+    internal sealed class LeaderElectionOptionsExtension : ICapOptionsExtension
+    {
+        private readonly Action<LeaderElectionOptions> _options;
+
+        public LeaderElectionOptionsExtension(Action<LeaderElectionOptions> option)
+        {
+            _options = option;
+        }
+
+        public void AddServices(IServiceCollection services)
+        {
+            var leaderElectionOptions = new LeaderElectionOptions();
+
+            _options?.Invoke(leaderElectionOptions);
+            services.AddSingleton(leaderElectionOptions);
+
+            services.AddSingleton<ILeaderElectionService>(r=>new ConsulLeaderElectionService(leaderElectionOptions));
+        }
+    }
+
+    public static class CapLeaderElectionOptionsExtensions
+    {
+        public static CapOptions UseLeaderElection(this CapOptions capOptions)
+        {
+            return capOptions.UseLeaderElection(opt => { });
+        }
+
+        public static CapOptions UseLeaderElection(this CapOptions capOptions, Action<LeaderElectionOptions> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            capOptions.RegisterExtension(new LeaderElectionOptionsExtension(options));
+
+            return capOptions;
+        }
+    }
+}

--- a/src/DotNetCore.CAP.LeaderElection/ConsulLeaderElectionService.cs
+++ b/src/DotNetCore.CAP.LeaderElection/ConsulLeaderElectionService.cs
@@ -1,0 +1,41 @@
+﻿using Consul;
+using DotNetCore.CAP.Internal;
+using System;
+using System.Threading.Tasks;
+
+namespace DotNetCore.CAP.LeaderElection
+{
+    public class ConsulLeaderElectionService : ILeaderElectionService,IDisposable
+    {
+        private readonly IDistributedLock _session;
+        private LeaderElectionOptions _leaderElectionOptions;
+        public ConsulLeaderElectionService(LeaderElectionOptions leaderElectionOptions)
+        {
+            _leaderElectionOptions = leaderElectionOptions;
+            var consulClient = new ConsulClient(config =>
+            {
+                config.WaitTime = TimeSpan.FromSeconds(5);
+                config.Address = new Uri($"http://{_leaderElectionOptions.ServerHostName}:{_leaderElectionOptions.ServerPort}");
+            });
+            _session = consulClient.CreateLock(leaderElectionOptions.LockName);            
+        }
+
+        public bool IsLeader()
+        {
+            _session.Acquire();
+            return _session.IsHeld;
+        }
+        public void Dispose()
+        {
+            Task.WaitAll(
+                Task.Run(() =>
+                {
+                    _session.Release();
+                }),
+                Task.Run(() =>
+                {
+                    _session.Destroy();
+                }));
+        }
+    }
+}

--- a/src/DotNetCore.CAP.LeaderElection/DotNetCore.CAP.LeaderElection.csproj
+++ b/src/DotNetCore.CAP.LeaderElection/DotNetCore.CAP.LeaderElection.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetCore.CAP\DotNetCore.CAP.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Consul" Version="1.6.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
+++ b/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // Warning: IPublishMessageSender need to inject at extension project. 
             services.TryAddSingleton<ISubscribeDispatcher, SubscribeDispatcher>();
 
+            // Leader election service
+            services.TryAddSingleton<ILeaderElectionService, LeaderElectionService>();
+
             //Options and extension service
             var options = new CapOptions();
             setupAction(options);

--- a/src/DotNetCore.CAP/Internal/ILeaderElectionService.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ILeaderElectionService.Default.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetCore.CAP.Internal
+{
+	public class LeaderElectionService : ILeaderElectionService
+	{
+		public bool IsLeader() => true;
+	}
+}

--- a/src/DotNetCore.CAP/Internal/ILeaderElectionService.cs
+++ b/src/DotNetCore.CAP/Internal/ILeaderElectionService.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetCore.CAP.Internal
+{
+    public interface ILeaderElectionService
+    {
+        bool IsLeader();
+    }
+}

--- a/src/DotNetCore.CAP/Processor/IProcessor.NeedRetry.cs
+++ b/src/DotNetCore.CAP/Processor/IProcessor.NeedRetry.cs
@@ -42,6 +42,9 @@ namespace DotNetCore.CAP.Processor
 
             var storage = context.Provider.GetRequiredService<IDataStorage>();
 
+            var leaderElectionService = context.Provider.GetRequiredService<ILeaderElectionService>();
+            if (!leaderElectionService.IsLeader()) return;
+
             await Task.WhenAll(ProcessPublishedAsync(storage, context), ProcessReceivedAsync(storage, context));
 
             await context.WaitAsync(_waitingInterval);

--- a/src/ILeaderElectionService.Default.cs
+++ b/src/ILeaderElectionService.Default.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetCore.CAP.Internal
+{
+	public class LeaderElectionService : ILeaderElectionService
+	{
+		public bool IsLeader() => true;
+	}
+}

--- a/src/ILeaderElectionService.cs
+++ b/src/ILeaderElectionService.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetCore.CAP.Internal
+{
+    public interface ILeaderElectionService
+    {
+        bool IsLeader();
+    }
+}


### PR DESCRIPTION
If you want processing only one node for failed messages, you can use this extension.