### PR TITLE
Add support for group and topic prefixes

### DIFF
--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -35,6 +35,16 @@ namespace DotNetCore.CAP
         public string DefaultGroup { get; set; }
 
         /// <summary>
+        /// Subscriber group prefix.
+        /// </summary>
+        public string GroupNamePrefix { get; set; }
+        
+        /// <summary>
+        /// Topic prefix.
+        /// </summary>
+        public string TopicNamePrefix { get; set; }
+
+        /// <summary>
         /// The default version of the message, configured to isolate data in the same instance. The length must not exceed 20
         /// </summary>
         public string Version { get; set; }

--- a/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
+++ b/src/DotNetCore.CAP/Internal/ConsumerExecutorDescriptor.cs
@@ -24,6 +24,8 @@ namespace DotNetCore.CAP.Internal
 
         public IList<ParameterDescriptor> Parameters { get; set; }
 
+        public string TopicNamePrefix { get; set; }
+
         private string _topicName;
         /// <summary>
         /// Topic name based on both <see cref="Attribute"/> and <see cref="ClassAttribute"/>.
@@ -42,6 +44,11 @@ namespace DotNetCore.CAP.Internal
                     else
                     {
                         _topicName = Attribute.Name;
+                    }
+
+                    if (!string.IsNullOrEmpty(TopicNamePrefix) && !string.IsNullOrEmpty(_topicName))
+                    {
+                        _topicName = $"{TopicNamePrefix}.{_topicName}";
                     }
                 }
                 return _topicName;

--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -11,6 +11,7 @@ using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Transport;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.Internal
 {
@@ -18,6 +19,7 @@ namespace DotNetCore.CAP.Internal
     {
         private readonly IDispatcher _dispatcher;
         private readonly IDataStorage _storage;
+        private readonly CapOptions _capOptions;
 
         // ReSharper disable once InconsistentNaming
         protected static readonly DiagnosticListener s_diagnosticListener =
@@ -28,6 +30,7 @@ namespace DotNetCore.CAP.Internal
             ServiceProvider = service;
             _dispatcher = service.GetRequiredService<IDispatcher>();
             _storage = service.GetRequiredService<IDataStorage>();
+            _capOptions = service.GetService<IOptions<CapOptions>>().Value;
             Transaction = new AsyncLocal<ICapTransaction>();
         }
 
@@ -61,6 +64,11 @@ namespace DotNetCore.CAP.Internal
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentNullException(nameof(name));
+            }
+
+            if (!string.IsNullOrEmpty(_capOptions.TopicNamePrefix))
+            {
+                name = $"{_capOptions.TopicNamePrefix}.{name}";
             }
 
             headers ??= new Dictionary<string, string>();

--- a/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerServiceSelector.Default.cs
@@ -59,6 +59,11 @@ namespace DotNetCore.CAP.Internal
                 return null;
             }
 
+            if (!string.IsNullOrEmpty(_capOptions.TopicNamePrefix))
+            {
+                key = $"{_capOptions.TopicNamePrefix}.{key}";
+            }
+
             var result = MatchUsingName(key, executeDescriptor);
             if (result != null)
             {
@@ -165,10 +170,13 @@ namespace DotNetCore.CAP.Internal
 
         protected virtual void SetSubscribeAttribute(TopicAttribute attribute)
         {
-            attribute.Group = (attribute.Group ?? _capOptions.DefaultGroup) + "." + _capOptions.Version;
+            var prefix = !string.IsNullOrEmpty(_capOptions.GroupNamePrefix)
+                ? $"{_capOptions.GroupNamePrefix}."
+                : string.Empty;
+            attribute.Group =  $"{prefix}{attribute.Group ?? _capOptions.DefaultGroup}.{_capOptions.Version}";
         }
 
-        private static ConsumerExecutorDescriptor InitDescriptor(
+        private ConsumerExecutorDescriptor InitDescriptor(
             TopicAttribute attr,
             MethodInfo methodInfo,
             TypeInfo implType,
@@ -183,7 +191,8 @@ namespace DotNetCore.CAP.Internal
                 MethodInfo = methodInfo,
                 ImplTypeInfo = implType,
                 ServiceTypeInfo = serviceTypeInfo,
-                Parameters = parameters
+                Parameters = parameters,
+                TopicNamePrefix = _capOptions.TopicNamePrefix
             };
 
             return descriptor;

--- a/test/DotNetCore.CAP.Test/CustomConsumerSubscribeTest.cs
+++ b/test/DotNetCore.CAP.Test/CustomConsumerSubscribeTest.cs
@@ -12,6 +12,9 @@ namespace DotNetCore.CAP.Test
 {
     public class CustomConsumerSubscribeTest
     {
+        private const string TopicNamePrefix = "topic";
+        private const string GroupNamePrefix = "group";
+
         private readonly IServiceProvider _provider;
 
         public CustomConsumerSubscribeTest()
@@ -20,7 +23,11 @@ namespace DotNetCore.CAP.Test
             services.AddSingleton<IConsumerServiceSelector, MyConsumerServiceSelector>();
             services.AddTransient<IMySubscribe, CustomInterfaceTypesClass>();
             services.AddLogging();
-            services.AddCap(x => { });
+            services.AddCap(x =>
+            {
+                x.TopicNamePrefix = TopicNamePrefix;
+                x.GroupNamePrefix = GroupNamePrefix;
+            });
             _provider = services.BuildServiceProvider();
         }
 
@@ -42,6 +49,8 @@ namespace DotNetCore.CAP.Test
 
             Assert.NotNull(bestCandidates);
             Assert.NotNull(bestCandidates.MethodInfo);
+            Assert.StartsWith(GroupNamePrefix, bestCandidates.Attribute.Group);
+            Assert.StartsWith(TopicNamePrefix, bestCandidates.TopicName);
             Assert.Equal(typeof(Task), bestCandidates.MethodInfo.ReturnType);
         }
     }
@@ -102,6 +111,11 @@ namespace DotNetCore.CAP.Test
                         attr.Group = attr.Group + "." + _capOptions.Version;
                     }
 
+                    if (!string.IsNullOrEmpty(_capOptions.GroupNamePrefix))
+                    {
+                        attr.Group = $"{_capOptions.GroupNamePrefix}.{attr.Group}";
+                    }
+
                     yield return new ConsumerExecutorDescriptor
                     {
                         Attribute = new CapSubscribeAttribute(attr.Name)
@@ -109,7 +123,8 @@ namespace DotNetCore.CAP.Test
                             Group = attr.Group
                         },
                         MethodInfo = method,
-                        ImplTypeInfo = typeInfo
+                        ImplTypeInfo = typeInfo,
+                        TopicNamePrefix = _capOptions.TopicNamePrefix
                     };
                 }
             }


### PR DESCRIPTION
**Problem**
We have multiple instances of the app, which deployed to AWS in different VPCs but in the same region. In this scenario, isolation works perfectly except for SNS and SQS, which are shared within the region.

**Proposed solution**
Add to `CapOptions` prefixes for topic (`TopicNamePrefix `) and group (`GroupNamePrefix `) names to make these parameters unique for each application instance. These parameters are optional, and if not defined the behavior will remain unchanged.

