### PR TITLE
Improvements to AWS topic subscription and SQS access policy generation

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.Auth.AccessControlPolicy;
+using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
+
+namespace DotNetCore.CAP.AmazonSQS
+{
+    public static class AmazonPolicyExtensions
+    {
+        /// <summary>
+        /// Check to see if the policy for the queue has already given permission to the topic.
+        /// </summary>
+        /// <param name="policy"></param>
+        /// <param name="topicArn"></param>
+        /// <param name="sqsQueueArn"></param>
+        /// <returns></returns>
+        public static bool HasSqsPermission(this Policy policy, string topicArn, string sqsQueueArn)
+        {
+            foreach (var statement in policy.Statements)
+            {
+                var containsResource = statement.Resources.Any(r => r.Id.Equals(sqsQueueArn));
+
+                if (!containsResource)
+                {
+                    continue;
+                }
+
+                foreach (var condition in statement.Conditions)
+                {
+                    if ((string.Equals(condition.Type, ConditionFactory.StringComparisonType.StringLike.ToString(), StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(condition.Type, ConditionFactory.StringComparisonType.StringEquals.ToString(), StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(condition.Type, ConditionFactory.ArnComparisonType.ArnEquals.ToString(), StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(condition.Type, ConditionFactory.ArnComparisonType.ArnLike.ToString(), StringComparison.OrdinalIgnoreCase)) &&
+                        string.Equals(condition.ConditionKey, ConditionFactory.SOURCE_ARN_CONDITION_KEY, StringComparison.OrdinalIgnoreCase) &&
+                        condition.Values.Contains(topicArn))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Add statement to the SQS policy that gives the SNS topics access to send a message to the queue.
+        /// </summary>
+        /// <code>
+        /// {
+        ///     "Version": "2012-10-17",
+        ///     "Statement": [
+        ///     {
+        ///         "Effect": "Allow",
+        ///         "Principal": {
+        ///             "AWS": "*"
+        ///         },
+        ///         "Action": "sqs:SendMessage",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Condition": {
+        ///             "ArnLike": {
+        ///                 "aws:SourceArn": [
+        ///                 "arn:aws:sns:us-east-1:FirstTopic",
+        ///                 "arn:aws:sns:us-east-1:SecondTopic"
+        ///                     ]
+        ///             }
+        ///         }
+        ///     }]
+        /// }
+        /// </code>
+        /// <param name="policy"></param>
+        /// <param name="topicArns"></param>
+        /// <param name="sqsQueueArn"></param>
+        public static void AddSqsPermissions(this Policy policy, IEnumerable<string> topicArns, string sqsQueueArn)
+        {
+            var statement = new Statement(Statement.StatementEffect.Allow);
+            statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+            statement.Resources.Add(new Resource(sqsQueueArn));
+            statement.Principals.Add(new Principal("*"));
+            foreach (var topicArn in topicArns)
+            {
+                statement.Conditions.Add(ConditionFactory.NewSourceArnCondition(topicArn));
+            }
+
+            policy.Statements.Add(statement);
+        }
+
+        /// <summary>
+        /// Compact SQS access policy
+        /// </summary>
+        /// <para>
+        /// Transforms policies with multiple similar statements:
+        /// <code>
+        /// {
+        ///     "Version": "2012-10-17",
+        ///     "Statement": [
+        ///     {
+        ///         "Effect": "Allow",
+        ///         "Principal": {
+        ///             "AWS": "*"
+        ///         },
+        ///         "Action": "sqs:SendMessage",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Condition": {
+        ///             "ArnLike": {
+        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:FirstTopic"
+        ///             }
+        ///         }
+        ///     },
+        ///     {
+        ///         "Effect": "Allow",
+        ///         "Principal": {
+        ///             "AWS": "*"
+        ///         },
+        ///         "Action": "sqs:SendMessage",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Condition": {
+        ///             "ArnLike": {
+        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:SecondTopic"
+        ///             }
+        ///         }
+        ///     }]
+        /// }
+        /// </code>
+        ///     into compacted single statement:
+        /// <code>
+        /// {
+        ///     "Version": "2012-10-17",
+        ///     "Statement": [
+        ///     {
+        ///         "Effect": "Allow",
+        ///         "Principal": {
+        ///             "AWS": "*"
+        ///         },
+        ///         "Action": "sqs:SendMessage",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Condition": {
+        ///             "ArnLike": {
+        ///                 "aws:SourceArn": [
+        ///                 "arn:aws:sns:us-east-1:FirstTopic",
+        ///                 "arn:aws:sns:us-east-1:SecondTopic"
+        ///                     ]
+        ///             }
+        ///         }
+        ///     }]
+        /// }
+        /// </code>
+        /// </para>
+        /// <param name="policy"></param>
+        /// <param name="sqsQueueArn"></param>
+        public static void CompactSqsPermissions(this Policy policy, string sqsQueueArn)
+        {
+            var statementsToCompact = policy.Statements
+                .Where(s => s.Effect == Statement.StatementEffect.Allow)
+                .Where(s => s.Actions.All(a => string.Equals(a.ActionName, SQSActionIdentifiers.SendMessage.ActionName, StringComparison.OrdinalIgnoreCase)))
+                .Where(s => s.Resources.All(r => string.Equals(r.Id, sqsQueueArn, StringComparison.OrdinalIgnoreCase)))
+                .Where(s => s.Principals.All(r => string.Equals(r.Id, "*", StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            if (statementsToCompact.Count < 2)
+            {
+                return;
+            }
+
+            var topicArns = new HashSet<string>();
+            foreach (var statement in statementsToCompact)
+            {
+                policy.Statements.Remove(statement);
+                foreach (var topicArn in statement.Conditions.SelectMany(c => c.Values))
+                {
+                    topicArns.Add(topicArn);
+                }
+            }
+
+            policy.AddSqsPermissions(topicArns, sqsQueueArn);
+        }
+    }
+}

--- a/src/DotNetCore.CAP/Transport/IConsumerClient.cs
+++ b/src/DotNetCore.CAP/Transport/IConsumerClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using DotNetCore.CAP.Messages;
 using JetBrains.Annotations;
@@ -16,6 +17,16 @@ namespace DotNetCore.CAP.Transport
     public interface IConsumerClient : IDisposable
     {
         BrokerAddress BrokerAddress { get; }
+
+        /// <summary>
+        /// Create (if necessary) and get topic identifiers
+        /// </summary>
+        /// <param name="topicNames">Names of the requested topics</param>
+        /// <returns>Topic identifiers</returns>
+        ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
 
         /// <summary>
         /// Subscribe to a set of topics to the message queue


### PR DESCRIPTION
There are few problems with `DotNetCore.CAP.AmazonSQS` provider. Our setup includes about 150 topics and about 15 queues. CAP is configured with `ConsumerThreadCount = 4`. This results in about 700 subscriptions.

**Problem 1**
When executing CAP with this configuration the subscription to SNS fails with the error `AmazonSimpleNotificationServiceException: Rate exceeded` and then required queues not created. This relates to the 
 `snsClient.CreateTopicAsync` call and occurs because AWS cannot process so many concurrent requests of SNS topic creation at a time.

**Proposed solution to Problem 1**
Separate topic creation and subscription process (i.e. extract topic creation out of the consumer threads). I have added `FetchTopics` method to `IConsumerClient` which returns a list of topics by default, but for AmazonSQS provider it handles the logic for SNS topic creation and/or its ARN fetching. This method is called before consumer threads creation.

**Problem 2**
When subscribing more than 20 SNS topics to the queue the access policy generated incorrectly and only the first 20 topics are able to post messages into the queue.

**Proposed solution to Problem 2**
This relates to the internal limit for SQS access policy to include only 20 statements. Thus to enable more than 20 SNS topics access to a single SQS we need to compact policy from:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:us-east-1:MyQueue",
      "Condition": {
        "ArnLike": {
          "aws:SourceArn": "arn:aws:sns:us-east-1:FirstTopic"
        }
      }
    },
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:us-east-1:MyQueue",
      "Condition": {
        "ArnLike": {
          "aws:SourceArn": "arn:aws:sns:us-east-1:SecondTopic"
        }
      }
    }]
}
```
to the compacted version with a single statement:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:us-east-1:MyQueue",
      "Condition": {
        "ArnLike": {
          "aws:SourceArn": [
          "arn:aws:sns:us-east-1:FirstTopic",
          "arn:aws:sns:us-east-1:SecondTopic"
          ]
        }
      }
    }]
}
```
After examination of AWS SDK, I have ended up with `AmazonPolicyExtensions` extensions, which help to achieve this.

Both improvements affect only  `DotNetCore.CAP.AmazonSQS` provider, but require changes in `DotNetCore.CAP` since the execution of the `FetchTopics` method needs to be added to `ConsumerRegister`