### PR TITLE
Fixed SQL content filter on IMonitoringApi.PostgreSql.cs

### DIFF
--- a/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
@@ -81,7 +81,7 @@ namespace DotNetCore.CAP.PostgreSql
 
             if (!string.IsNullOrEmpty(queryDto.Group)) where += " and Lower(\"Group\") = Lower(@Group)";
 
-            if (!string.IsNullOrEmpty(queryDto.Content)) where += " and \"Content\" ILike concat('%',@Content,'%')";
+            if (!string.IsNullOrEmpty(queryDto.Content)) where += " and \"Content\" ILike @Content";
 
             var sqlQuery =
                 $"select * from {tableName} where 1=1 {where} order by \"Added\" desc offset @Offset limit @Limit";


### PR DESCRIPTION
Was trying to filter the Dashboard by some of the message properties (content) and it was not working. After investigating, found out that the generated SQL as wrong. Since the % is already placed within the NpgsqlParameter on the line 94, the filter on the line 84 was wrongly placed and can be simplified.

This fixes this issue and the content filter now behaves properly.