### PR TITLE
Added DefaultChallengeScheme to Dashboard authentication middleware

### DIFF
--- a/samples/Sample.RabbitMQ.Postgres.DashboardAuth/Startup.cs
+++ b/samples/Sample.RabbitMQ.Postgres.DashboardAuth/Startup.cs
@@ -62,6 +62,7 @@ namespace Sample.RabbitMQ.Postgres.DashboardAuth
                 cap.UseDashboard(d =>
                 {
                     d.UseChallengeOnAuth = true;
+                    d.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
                     d.Authorization = new[] {new HttpContextDashboardFilter()};
                 });
             });

--- a/src/DotNetCore.CAP.Dashboard/CAP.DashboardMiddleware.cs
+++ b/src/DotNetCore.CAP.Dashboard/CAP.DashboardMiddleware.cs
@@ -136,7 +136,7 @@ namespace DotNetCore.CAP
 
                     if (_options.UseChallengeOnAuth)
                     {
-                        await context.ChallengeAsync();
+                        await context.ChallengeAsync(_options.DefaultChallengeScheme);
                         return;
                     }
 

--- a/src/DotNetCore.CAP.Dashboard/CAP.DashboardOptions.cs
+++ b/src/DotNetCore.CAP.Dashboard/CAP.DashboardOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using DotNetCore.CAP.Dashboard;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP
@@ -18,6 +19,11 @@ namespace DotNetCore.CAP
             UseChallengeOnAuth = false;
         }
 
+        /// <summary>
+        /// Default ChallengeScheme used for Dashboard authentication. If no scheme is set, the DefaultScheme set up in AddAuthentication will be used.
+        /// </summary>
+        public string DefaultChallengeScheme { get; set; }
+        
         /// <summary>
         /// Indicates if executes a Challenge for Auth within ASP.NET middlewares
         /// </summary>


### PR DESCRIPTION
This PR adds a DefaultChallengeScheme property to CAP.DashboardOptions.cs that sets up the scheme to be used when the Dashboard uses authentication via Challenge using the ASP.NET middlewares. If none is setup, the default of the application will be used.

It is useful for application with multiple authentication schemes.

Updated the sample as well.