### PR TITLE
Add support for Azure Service Bus sessions

### DIFF
--- a/docs/content/user-guide/en/transport/azure-service-bus.md
+++ b/docs/content/user-guide/en/transport/azure-service-bus.md
@@ -41,5 +41,24 @@ The AzureServiceBus configuration options provided directly by the CAP:
 NAME | DESCRIPTION | TYPE | DEFAULT
 :---|:---|---|:---
 ConnectionString | Endpoint address | string | 
+EnableSessions | Enable [Service bus sessions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions) | bool | false 
 TopicPath | Topic entity path | string | cap
 ManagementTokenProvider | Token provider | ITokenProvider | null
+
+#### Sessions
+
+When sessions are enabled (see `EnableSessions` option above), every message sent will have a session id. To control the session id, include
+an extra header with name `AzureServiceBusHeaders.SessionId` when publishing events:
+
+```csharp
+ICapPublisher capBus = ...;
+string yourEventName = ...;
+YourEventType yourEvent = ...;
+
+Dictionary<string, string> extraHeaders = new Dictionary<string, string>();
+extraHeaders.Add(AzureServiceBusHeaders.SessionId, <your-session-id>);
+
+capBus.Publish(yourEventName, yourEvent, extraHeaders);
+```
+
+If no session id header is present, the message id will be used as the session id.

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
@@ -1,0 +1,16 @@
+using Microsoft.Azure.ServiceBus;
+
+namespace DotNetCore.CAP.AzureServiceBus
+{
+    public class AzureServiceBusConsumerCommitInput
+    {
+        public AzureServiceBusConsumerCommitInput(string lockToken, IMessageSession session = null)
+        {
+            LockToken = lockToken;
+            Session = session;
+        }
+        
+        public IMessageSession Session { get; set; }
+        public string LockToken { get; set; }
+    }
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusHeaders.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusHeaders.cs
@@ -1,0 +1,7 @@
+namespace DotNetCore.CAP.AzureServiceBus
+{
+    public static class AzureServiceBusHeaders
+    {
+        public const string SessionId = "cap-session-id";
+    }
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using DotNetCore.CAP.AzureServiceBus;
 using Microsoft.Azure.ServiceBus.Primitives;
 
 // ReSharper disable once CheckNamespace
@@ -20,6 +21,12 @@ namespace DotNetCore.CAP
         /// Azure Service Bus Namespace connection string. Must not contain topic information.
         /// </summary>
         public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Whether Service Bus sessions are enabled. If enabled, all messages must contain a
+        /// <see cref="AzureServiceBusHeaders.SessionId"/> header. Defaults to false.
+        /// </summary>
+        public bool EnableSessions { get; set; } = false;
 
         /// <summary>
         /// The name of the topic relative to the service namespace base address.

--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -46,6 +46,12 @@ namespace DotNetCore.CAP.AzureServiceBus
                     CorrelationId = transportMessage.GetCorrelationId()
                 };
 
+                if (_asbOptions.Value.EnableSessions)
+                {
+                    transportMessage.Headers.TryGetValue(AzureServiceBusHeaders.SessionId, out var sessionId);
+                    message.SessionId = string.IsNullOrEmpty(sessionId) ? transportMessage.GetId() : sessionId;
+                }
+
                 foreach (var header in transportMessage.Headers)
                 {
                     message.UserProperties.Add(header.Key, header.Value);


### PR DESCRIPTION
As discussed in #828, this is a PR to add session support for Azure Service Bus.

Adds a new config option `EnableSessions` for Azure Service Bus. Session support must be explicitly enabled. When disabled, CAP works like before.

When sessions are enabled:

  * `RequiresSession` is set on auto-created subscriptions
  * The `SessionId` property is set on the Service Bus Message
    * uses the value of the `cap-session-id` header, when present
    * otherwise falls back to using the message id (similar to the handling of `cap-kafka-key`)
  * RegisterSessionHandler is used instead of RegisterMessageHandler when consuming events

There is also some brief documentation on the feature, how to enable and use it (in English, possibly needs translation?).

As we don't use CAP on the consumer side ourselves, this part is unfortunately not well tested.

Suggestions welcome!