### PR TITLE
DiagnosticObserver does not use null connection

### DIFF
--- a/src/DotNetCore.CAP.SqlServer/Diagnostics/DiagnosticObserver.cs
+++ b/src/DotNetCore.CAP.SqlServer/Diagnostics/DiagnosticObserver.cs
@@ -40,7 +40,7 @@ namespace DotNetCore.CAP.SqlServer.Diagnostics
         {
             if (evt.Key == SqlAfterCommitTransaction || evt.Key == SqlAfterCommitTransactionMicrosoft)
             {
-                var sqlConnection = (SqlConnection)GetProperty(evt.Value, "Connection");
+                if (!GetSqlConnection(evt, out SqlConnection sqlConnection)) return;
                 var transactionKey = sqlConnection.ClientConnectionId;
                 if (_bufferList.TryRemove(transactionKey, out var msgList))
                     foreach (var message in msgList)
@@ -50,11 +50,17 @@ namespace DotNetCore.CAP.SqlServer.Diagnostics
             }
             else if (evt.Key == SqlErrorCommitTransaction || evt.Key == SqlErrorCommitTransactionMicrosoft)
             {
-                var sqlConnection = (SqlConnection)GetProperty(evt.Value, "Connection");
+                if (!GetSqlConnection(evt, out SqlConnection sqlConnection)) return;
                 var transactionKey = sqlConnection.ClientConnectionId;
 
                 _bufferList.TryRemove(transactionKey, out _);
             }
+        }
+
+        private bool GetSqlConnection(KeyValuePair<string, object> evt, out SqlConnection sqlConnection)
+        {
+            sqlConnection = GetProperty(evt.Value, "Connection") as SqlConnection;
+            return sqlConnection != null;
         }
 
         private static object GetProperty(object _this, string propertyName)


### PR DESCRIPTION
DiagnosticObserver returns rather than using a possible null SqlConnection that may come from another component.