### PR TITLE
Fix null reference in AmazonSQSTransport

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
@@ -65,12 +65,16 @@ namespace DotNetCore.CAP.AmazonSQS
                     return OperateResult.Success;
                 }
 
-                _logger.LogWarning($"Can't be found SNS topics for [{message.GetName().NormalizeForAws()}]");
-                return OperateResult.Failed(new OperateError
-                {
-                    Code = "SNS",
-                    Description = $"Can't be found SNS topics for [{message.GetName().NormalizeForAws()}]"
-                });
+                var errorMessage = $"Can't be found SNS topics for [{message.GetName().NormalizeForAws()}]";
+                _logger.LogWarning(errorMessage);
+
+                return OperateResult.Failed(
+                    new PublisherSentFailedException(errorMessage),
+                    new OperateError
+                    {
+                        Code = "SNS",
+                        Description = $"Can't be found SNS topics for [{message.GetName().NormalizeForAws()}]"
+                    });
             }
             catch (Exception ex)
             {

--- a/src/DotNetCore.CAP/OperateResult.cs
+++ b/src/DotNetCore.CAP/OperateResult.cs
@@ -41,22 +41,12 @@ namespace DotNetCore.CAP
         /// Creates an <see cref="OperateResult" /> indicating a failed operation, with a list of <paramref name="errors" /> if
         /// applicable.
         /// </summary>
+        /// <param name="ex">Operate Result exception</param>
         /// <param name="errors">An optional array of <see cref="OperateError" />s which caused the operation to fail.</param>
         /// <returns>
         /// An <see cref="OperateResult" /> indicating a failed operation, with a list of <paramref name="errors" /> if
         /// applicable.
         /// </returns>
-        public static OperateResult Failed(params OperateError[] errors)
-        {
-            var result = new OperateResult {Succeeded = false};
-            if (errors != null)
-            {
-                result._errors.AddRange(errors);
-            }
-
-            return result;
-        }
-
         public static OperateResult Failed(Exception ex, params OperateError[] errors)
         {
             var result = new OperateResult


### PR DESCRIPTION
**Problem**
The `NullReferenceException` by `DotNetCore.CAP.Messages.MessageExtensions.AddOrUpdateException` when no SNS topics found in `AmazonSQSTransport`.

**Proposed solution**
This is related to the usage old overload of `OperateResult` in `AmazonSQSTransport`, which does not accept an exception. It is not valid anymore, since `MessageSender` expecting that exception is not null when message failed.
Removed obsolete overload `OperateResult Failed(params OperateError[] errors)` and used a recent one in `AmazonSQSTransport`