### PR TITLE
Fix RabbitMQ connection was closed unexpectedly.

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
@@ -67,13 +67,17 @@ namespace DotNetCore.CAP.RabbitMQ
 
         public IConnection GetConnection()
         {
-            if (_connection != null && _connection.IsOpen)
+            lock (SLock)
             {
+                if (_connection != null && _connection.IsOpen)
+                {
+                    return _connection;
+                }
+
+                _connection?.Dispose();
+                _connection = _connectionActivator();
                 return _connection;
             }
-
-            _connection = _connectionActivator();
-            return _connection;
         }
 
         public void Dispose()
@@ -84,6 +88,7 @@ namespace DotNetCore.CAP.RabbitMQ
             {
                 context.Dispose();
             }
+            _connection?.Dispose();
         }
 
         private static Func<IConnection> CreateConnection(RabbitMQOptions options)

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -92,7 +92,8 @@ namespace DotNetCore.CAP.RabbitMQ
         public void Dispose()
         {
             _channel?.Dispose();
-            _connection?.Dispose();
+            //The connection should not be closed here, because the connection is still in use elsewhere. 
+            //_connection?.Dispose();
         }
 
         public void Connect()


### PR DESCRIPTION
In the `Dispose` method of `RabbitMQConsumerClient`, the connection should not be closed because the connection is reused.  

#861 
