### PR TITLE
Implementing IInfrastructure interface in order to the GetDbTransaction extension method of EF core work

### DIFF
--- a/src/DotNetCore.CAP.PostgreSql/IDbContextTransaction.CAP.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDbContextTransaction.CAP.cs
@@ -2,14 +2,16 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetCore.CAP;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Storage
 {
-    internal class CapEFDbTransaction : IDbContextTransaction
+    internal class CapEFDbTransaction : IDbContextTransaction, IInfrastructure<DbTransaction>
     {
         private readonly ICapTransaction _transaction;
 
@@ -50,6 +52,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ValueTask DisposeAsync()
         {
             return new ValueTask(Task.Run(() => _transaction.Dispose()));
+        }
+
+        public DbTransaction Instance
+        {
+            get
+            {
+                var dbContextTransaction = (IDbContextTransaction) _transaction.DbTransaction;
+                return dbContextTransaction.GetDbTransaction();
+            }
         }
     }
 }


### PR DESCRIPTION
Applying the same fix realized for sql server transaction interface ([issue explained here](https://github.com/dotnetcore/CAP/issues/867))  to the postgresql transaction interface.

Brief overview: the problem is that the EF Core GetDbTransaction method ([extension method reference](https://github.com/dotnet/efcore/blob/main/src/EFCore.Relational/Storage/DbContextTransactionExtensions.cs)) is throwing InvalidOperationException because the CAP PostgreSQL transaction class is not implementing the required interface so the extension method can be executed.