### PR TITLE
Add subscribe filter support

### DIFF
--- a/src/DotNetCore.CAP/CAP.Builder.cs
+++ b/src/DotNetCore.CAP/CAP.Builder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using DotNetCore.CAP.Filter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/DotNetCore.CAP/CAP.Builder.cs
+++ b/src/DotNetCore.CAP/CAP.Builder.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace DotNetCore.CAP
 {
@@ -42,31 +42,9 @@ namespace DotNetCore.CAP
         /// </summary>
         public IServiceCollection Services { get; }
 
-        /// <summary>
-        /// Add an <see cref="ICapPublisher" />.
-        /// </summary>
-        /// <typeparam name="T">The type of the service.</typeparam>
-        public CapBuilder AddProducerService<T>()
-            where T : class, ICapPublisher
+        public CapBuilder AddSubscribeFilter<T>() where T : class, ISubscribeFilter
         {
-            return AddScoped(typeof(ICapPublisher), typeof(T));
-        }
-
-        /// <summary>
-        /// Adds a scoped service of the type specified in serviceType with an implementation
-        /// </summary>
-        private CapBuilder AddScoped(Type serviceType, Type concreteType)
-        {
-            Services.AddScoped(serviceType, concreteType);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a singleton service of the type specified in serviceType with an implementation
-        /// </summary>
-        private CapBuilder AddSingleton(Type serviceType, Type concreteType)
-        {
-            Services.AddSingleton(serviceType, concreteType);
+            Services.TryAddScoped<ISubscribeFilter, T>();
             return this;
         }
     }

--- a/src/DotNetCore.CAP/Internal/ConsumerContext.cs
+++ b/src/DotNetCore.CAP/Internal/ConsumerContext.cs
@@ -11,6 +11,12 @@ namespace DotNetCore.CAP.Internal
     /// </summary>
     public class ConsumerContext
     {
+        public ConsumerContext(ConsumerContext context)
+        : this(context.ConsumerDescriptor, context.DeliverMessage)
+        {
+
+        }
+
         /// <summary>
         /// create a new instance of  <see cref="ConsumerContext" /> .
         /// </summary>

--- a/src/DotNetCore.CAP/Internal/Filter/ExceptionContext.cs
+++ b/src/DotNetCore.CAP/Internal/Filter/ExceptionContext.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using DotNetCore.CAP.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace DotNetCore.CAP.Filter
+{
+    public class ExceptionContext : FilterContext
+    {
+        public ExceptionContext(ConsumerContext context, Exception e)
+            : base(context)
+        {
+            Exception = e;
+        }
+
+        public Exception Exception { get; set; }
+
+        public bool ExceptionHandled { get; set; }
+
+        public object Result { get; set; }
+    }
+}

--- a/src/DotNetCore.CAP/Internal/Filter/ExecutedContext.cs
+++ b/src/DotNetCore.CAP/Internal/Filter/ExecutedContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using DotNetCore.CAP.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace DotNetCore.CAP.Filter
+{
+    public class ExecutedContext : FilterContext
+    {
+        public ExecutedContext(ConsumerContext context, object result) : base(context)
+        {
+            Result = result;
+        }
+
+        public object Result { get; set; }
+    }
+}

--- a/src/DotNetCore.CAP/Internal/Filter/ExecutingContext.cs
+++ b/src/DotNetCore.CAP/Internal/Filter/ExecutingContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using DotNetCore.CAP.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace DotNetCore.CAP.Filter
+{
+    public class ExecutingContext : FilterContext
+    {
+        public ExecutingContext(ConsumerContext context, object[] arguments) : base(context)
+        {
+            Arguments = arguments;
+        }
+
+        public object[] Arguments { get; set; }
+    }
+}

--- a/src/DotNetCore.CAP/Internal/Filter/FilterContext.cs
+++ b/src/DotNetCore.CAP/Internal/Filter/FilterContext.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using DotNetCore.CAP.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace DotNetCore.CAP.Filter
+{
+    public class FilterContext : ConsumerContext
+    {
+        public FilterContext(ConsumerContext context) : base(context)
+        {
+
+        }
+    }
+}

--- a/src/DotNetCore.CAP/Internal/Filter/ISubscribeFilter.cs
+++ b/src/DotNetCore.CAP/Internal/Filter/ISubscribeFilter.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// ReSharper disable once CheckNamespace
+namespace DotNetCore.CAP.Filter
+{
+    /// <summary>
+    /// A filter that surrounds execution of the subscriber.
+    /// </summary>
+    public interface ISubscribeFilter
+    {
+        /// <summary>
+        /// Called before the subscriber executes.
+        /// </summary>
+        /// <param name="context">The <see cref="ExecutingContext"/>.</param>
+        void OnSubscribeExecuting(ExecutingContext context);
+
+        /// <summary>
+        /// Called after the subscriber executes.
+        /// </summary>
+        /// <param name="context">The <see cref="ExecutedContext"/>.</param>
+        void OnSubscribeExecuted(ExecutedContext context);
+
+        /// <summary>
+        /// Called after the subscriber has thrown an <see cref="System.Exception"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ExceptionContext"/>.</param>
+        void OnSubscribeException(ExceptionContext context);
+    }
+}

--- a/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
+++ b/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
@@ -40,19 +40,6 @@ namespace DotNetCore.CAP.Test
         }
 
         [Fact]
-        public void CanOverridePublishService()
-        {
-            var services = new ServiceCollection();
-            services.AddCap(x => { }).AddProducerService<MyProducerService>();
-
-            var thingy = services.BuildServiceProvider()
-                .GetRequiredService<ICapPublisher>() as MyProducerService;
-
-            Assert.NotNull(thingy);
-        }
-      
-
-        [Fact]
         public void CanResolveCapOptions()
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
## Motivation

Since CAP does not have filters or interceptors, in some scenarios additional operations, such as logging or enabling transaction management, need to be performed before and after the subscriber's execution.

Prior to this, this can be achieved with the help of third-party AOP components, such as the behavior described in the [article](https://cap.dotnetcore.xyz/user-guide/zh/samples/castle.dynamicproxy/) . But there are some limitations and precautions, such as the need to mark the method as viusal or the constructor injection behavior of the proxy class becomes complicated. 

Based on the above reasons, it is necessary to provide support for Filter.

## Implement

Provides support for custom filters through the `ISubscribeFilter` interface. Considering the complexity, currently does not provide support for multiple filters

## Usage

```C#
services.AddCap(cap =>
{
    cap.UseMySql();
    cap.UseRabbitMQ()
}.AddSubscribeFilter<MyCapFilter>()
```