### PR TITLE
fix:  health check path is changed to 'cap/api/health'

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/CapCache.cs
+++ b/src/DotNetCore.CAP.Dashboard/CapCache.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,7 +15,7 @@ namespace DotNetCore.CAP.Dashboard
     /// </summary>
     // ReSharper disable once InheritdocConsiderUsage
     // ReSharper disable once InconsistentNaming
-    internal class Cache<K, T> : IDisposable
+    public class Cache<K, T> : IDisposable
     {
         #region Constructor and class members
 
@@ -121,7 +121,7 @@ namespace DotNetCore.CAP.Dashboard
 
         private void RemoveByTimer(object state)
         {
-            Remove((K) state);
+            Remove((K)state);
         }
 
         #endregion
@@ -251,8 +251,8 @@ namespace DotNetCore.CAP.Dashboard
             try
             {
                 var removers = (from k in _cache.Keys.Cast<K>()
-                    where keyPattern(k)
-                    select k).ToList();
+                                where keyPattern(k)
+                                select k).ToList();
 
                 foreach (var workKey in removers)
                 {
@@ -354,7 +354,7 @@ namespace DotNetCore.CAP.Dashboard
     /// instance.
     /// The <c>.Global</c> member is lazy instanciated.
     /// </summary>
-    internal class CapCache : Cache<string, object>
+    public class CapCache : Cache<string, object>
     {
         #region Static Global Cache instance 
 

--- a/src/DotNetCore.CAP.Dashboard/NodeDiscovery/INodeDiscoveryProvider.Consul.cs
+++ b/src/DotNetCore.CAP.Dashboard/NodeDiscovery/INodeDiscoveryProvider.Consul.cs
@@ -77,7 +77,7 @@ namespace DotNetCore.CAP.Dashboard.NodeDiscovery
                 };
 
                 if (_options.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
-                    healthCheck.HTTP = $"http://{_options.CurrentNodeHostName}:{_options.CurrentNodePort}{_options.MatchPath}/health";
+                    healthCheck.HTTP = $"http://{_options.CurrentNodeHostName}:{_options.CurrentNodePort}{_options.MatchPath}/api/health";
                 else if (_options.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                     healthCheck.TCP = $"{_options.CurrentNodeHostName}:{_options.CurrentNodePort}";
 


### PR DESCRIPTION
1，修正health check 路径为 'cap/api/health'
2，开放CapCache，可自实现INodeDiscoveryProvider