### PR TITLE
Improvements to AWS provider

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
@@ -102,10 +102,10 @@ namespace DotNetCore.CAP.AmazonSQS
         ///             "AWS": "*"
         ///         },
         ///         "Action": "sqs:SendMessage",
-        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
         ///         "Condition": {
         ///             "ArnLike": {
-        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:FirstTopic"
+        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-FirstTopic"
         ///             }
         ///         }
         ///     },
@@ -115,13 +115,26 @@ namespace DotNetCore.CAP.AmazonSQS
         ///             "AWS": "*"
         ///         },
         ///         "Action": "sqs:SendMessage",
-        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
         ///         "Condition": {
         ///             "ArnLike": {
-        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:SecondTopic"
+        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-SecondTopic"
         ///             }
         ///         }
-        ///     }]
+        ///     },
+        ///     {
+        ///         "Effect": "Allow",
+        ///         "Principal": {
+        ///             "AWS": "*"
+        ///         },
+        ///         "Action": "sqs:SendMessage",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
+        ///         "Condition": {
+        ///             "ArnLike": {
+        ///                 "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue2-FirstTopic"
+        ///             }
+        ///         }
+        ///     },]
         /// }
         /// </code>
         ///     into compacted single statement:
@@ -135,13 +148,13 @@ namespace DotNetCore.CAP.AmazonSQS
         ///             "AWS": "*"
         ///         },
         ///         "Action": "sqs:SendMessage",
-        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue",
+        ///         "Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
         ///         "Condition": {
         ///             "ArnLike": {
         ///                 "aws:SourceArn": [
-        ///                 "arn:aws:sns:us-east-1:FirstTopic",
-        ///                 "arn:aws:sns:us-east-1:SecondTopic"
-        ///                     ]
+        ///                     "arn:aws:sns:us-east-1:MyQueue-*",
+        ///                     "arn:aws:sns:us-east-1:MyQueue2-FirstTopic"
+        ///                 ]
         ///             }
         ///         }
         ///     }]
@@ -161,7 +174,12 @@ namespace DotNetCore.CAP.AmazonSQS
                 .Where(s => s.Principals.All(r => string.Equals(r.Id, "*", StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
-            if (statementsToCompact.Count < 2)
+            var groupName = GetGroupName(sqsQueueArn);
+            if (groupName != null)
+            {
+                groupName = $":{groupName}-";
+            }
+            if (statementsToCompact.Count < 2 && groupName == null)
             {
                 return;
             }
@@ -172,11 +190,66 @@ namespace DotNetCore.CAP.AmazonSQS
                 policy.Statements.Remove(statement);
                 foreach (var topicArn in statement.Conditions.SelectMany(c => c.Values))
                 {
-                    topicArns.Add(topicArn);
+                    topicArns.Add(
+                        groupName != null && topicArn.Contains(groupName, StringComparison.InvariantCultureIgnoreCase)
+                            ? $"{GetArnGroupPrefix(topicArn)}-*"
+                            : topicArn);
                 }
             }
 
-            policy.AddSqsPermissions(topicArns, sqsQueueArn);
+            policy.AddSqsPermissions(topicArns.OrderBy(a => a), sqsQueueArn);
+        }
+
+        /// <summary>
+        /// Extract group prefix from ARN
+        /// For example for ARN:
+        ///     arn:aws:sns:us-east-1:MyQueue-FirstTopic
+        /// group prefix will be extracted:
+        ///     arn:aws:sns:us-east-1:MyQueue
+        /// </summary>
+        /// <param name="arn">Source ARN</param>
+        /// <returns>Group prefix or null if group not present</returns>
+        private static string GetArnGroupPrefix(string arn)
+        {
+            const char separator = '-';
+            if (string.IsNullOrEmpty(arn) || !arn.Contains(separator))
+            {
+                return null;
+            }
+
+            var groupPaths = arn.Split(separator);
+            if (groupPaths.Length < 2)
+            {
+                return null;
+            }
+
+            return string.Join(separator, groupPaths.Take(groupPaths.Length - 1));
+        }
+        
+        /// <summary>
+        /// Extract group name from ARN
+        /// For example for ARN:
+        ///     arn:aws:sns:us-east-1:MyQueue-FirstTopic
+        /// group name will be extracted:
+        ///     MyQueue
+        /// </summary>
+        /// <param name="arn">Source ARN</param>
+        /// <returns>Group name or null if group not present</returns>
+        private static string GetGroupName(string arn)
+        {
+            const char separator = ':';
+            if (string.IsNullOrEmpty(arn) || !arn.Contains(separator))
+            {
+                return null;
+            }
+
+            var name = arn.Split(separator).LastOrDefault();
+            if(string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            return GetArnGroupPrefix(name);
         }
     }
 }

--- a/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
@@ -37,9 +37,9 @@ namespace DotNetCore.CAP.AmazonSQS
         {
             try
             {
-                await TryAddTopicArns();
+                await FetchExistingTopicArns();
 
-                if (TryGetOrCreateTopic(message.GetName().NormalizeForAws(), out var arn))
+                if (TryGetOrCreateTopicArn(message.GetName().NormalizeForAws(), out var arn))
                 {
                     string bodyJson = null;
                     if (message.Body != null)
@@ -89,11 +89,11 @@ namespace DotNetCore.CAP.AmazonSQS
             }
         }
 
-        public async Task<bool> TryAddTopicArns()
+        private async Task FetchExistingTopicArns()
         {
             if (_topicArnMaps != null)
             {
-                return true;
+                return;
             }
 
             await _semaphore.WaitAsync();
@@ -122,8 +122,6 @@ namespace DotNetCore.CAP.AmazonSQS
                         nextToken = topics.NextToken;
                     }
                     while (!string.IsNullOrEmpty(nextToken));
-
-                    return true;
                 }
             }
             catch (Exception e)
@@ -134,11 +132,9 @@ namespace DotNetCore.CAP.AmazonSQS
             {
                 _semaphore.Release();
             }
-
-            return false;
         }
         
-        private bool TryGetOrCreateTopic(string topicName, out string topicArn)
+        private bool TryGetOrCreateTopicArn(string topicName, out string topicArn)
         {
             topicArn = null;
             if (_topicArnMaps.TryGetValue(topicName, out topicArn))


### PR DESCRIPTION
## Improvements to ITransport.AmazonSQS
- Added ability to create topic if it is not found in the topics cache
- Improved functions naming

## Improvements to SQS policy generation
**Problem 1**
In the production, we have faced [limitation of SQS policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-policies.html) - size 8192 b
**Proposed solution**
In previous PR https://github.com/dotnetcore/CAP/pull/808 I reduced policy size by combining statements for SNS access into one. Here I propose to replace all ARNs with wildcard if the prefixes for SNS and SQS name matches.
For example, there is SQS name `MyQueue` and three related topics:
```JSON
"Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
"Condition": {
    "ArnLike": {
        "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-FirstTopic",
        "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-SecondTopic",
        "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-ThirdTopic",
        "aws:SourceArn": "arn:aws:sns:us-east-1:SecondQueue-FirstTopic",
        "aws:SourceArn": "arn:aws:sns:us-east-1:SecondQueue-SecondTopic",
   }
}
```
If SNS name `MyQueue` mathes with topic prefixes this may be compacted to
```JSON
"Resource": "arn:aws:sqs:us-east-1:MyQueue-v1",
"Condition": {
    "ArnLike": {
        "aws:SourceArn": "arn:aws:sns:us-east-1:MyQueue-*",
        "aws:SourceArn": "arn:aws:sns:us-east-1:SecondQueue-FirstTopic",
        "aws:SourceArn": "arn:aws:sns:us-east-1:SecondQueue-SecondTopic",
   }
}
```
If the SNS name does not match (case with `SecondQueue`), topics would not be compacted.

**Problem 2**
Use of `_snsClient.SubscribeQueueToTopicsAsync` broke compactization of SQS policies.
**Solution**
After investigation of AWS SDK, it was found that `SubscribeQueueToTopicsAsync` internally calls regeneration of SQS policy, but it would not recognize correctly wildcards, thus adds explicitly ARN of each SNS topic. Since the policy is already generated in the function above, usage of `SubscribeQueueToTopicsAsync` was replaced with `SubscribeAsync`. This just ensures subscription to topic but does not regenerate policy.