### PR TITLE
Allows the overriding of the Kafka  ProviderBuilder and ConsumerBuilder 

### DIFF
--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -46,8 +46,15 @@ namespace DotNetCore.CAP.Kafka
                 RequestTimeoutMs = 3000
             };
 
-            producer = new ProducerBuilder<string, byte[]>(config).Build();
+            producer = BuildProducer(config);
 
+            return producer;
+        }
+
+        protected virtual IProducer<string, byte[]> BuildProducer(ProducerConfig config)
+        {
+            IProducer<string, byte[]> producer;
+            producer = new ProducerBuilder<string, byte[]>(config).Build();
             return producer;
         }
 

--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -53,9 +53,7 @@ namespace DotNetCore.CAP.Kafka
 
         protected virtual IProducer<string, byte[]> BuildProducer(ProducerConfig config)
         {
-            IProducer<string, byte[]> producer;
-            producer = new ProducerBuilder<string, byte[]>(config).Build();
-            return producer;
+            return  new ProducerBuilder<string, byte[]>(config).Build();
         }
 
         public bool Return(IProducer<string, byte[]> producer)

--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.Kafka
 {
-    internal sealed class KafkaConsumerClient : IConsumerClient
+    public class KafkaConsumerClient : IConsumerClient
     {
         private static readonly SemaphoreSlim ConnectionLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
@@ -153,15 +153,20 @@ namespace DotNetCore.CAP.Kafka
                     config.EnableAutoCommit ??= false;
                     config.LogConnectionClose ??= false;
 
-                    _consumerClient = new ConsumerBuilder<string, byte[]>(config)
-                        .SetErrorHandler(ConsumerClient_OnConsumeError)
-                        .Build();
+                    BuildConsumer(config);
                 }
             }
             finally
             {
                 ConnectionLock.Release();
             }
+        }
+
+        protected virtual void BuildConsumer(ConsumerConfig config)
+        {
+            _consumerClient = new ConsumerBuilder<string, byte[]>(config)
+                .SetErrorHandler(ConsumerClient_OnConsumeError)
+                .Build();
         }
 
         private void ConsumerClient_OnConsumeError(IConsumer<string, byte[]> consumer, Error e)

--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClientFactory.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClientFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.Kafka
 {
-    internal sealed class KafkaConsumerClientFactory : IConsumerClientFactory
+    public class KafkaConsumerClientFactory : IConsumerClientFactory
     {
         private readonly IOptions<KafkaOptions> _kafkaOptions;
 
@@ -15,7 +15,7 @@ namespace DotNetCore.CAP.Kafka
             _kafkaOptions = kafkaOptions;
         }
 
-        public IConsumerClient Create(string groupId)
+        public virtual IConsumerClient Create(string groupId)
         {
             try
             {


### PR DESCRIPTION
I would like control of the Kafka ProviderBuilder and ConsumerBuilder to allow decorators. 

No breaking changes. 
Opening up of visibility shouldn't affect performance as these classes are usually singletons and the methods are rarely called.
