### PR TITLE
Fix _isHealthy variable

### DIFF
--- a/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
@@ -35,7 +35,7 @@ namespace DotNetCore.CAP.Internal
         private BrokerAddress _serverAddress;
         private Task _compositeTask;
         private bool _disposed;
-        private static bool _isHealthy = true;
+        private bool _isHealthy = true;
 
         // diagnostics listener
         // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
The private static variable _isHealthy has no meaning in a singleton. If you use multi-host mode, there will be status detection problems