### PR TITLE
Do not update message Content when change state.

### DIFF
--- a/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
+++ b/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
@@ -34,7 +34,6 @@ namespace DotNetCore.CAP.InMemoryStorage
         {
             PublishedMessages[message.DbId].StatusName = state;
             PublishedMessages[message.DbId].ExpiresAt = message.ExpiresAt;
-            PublishedMessages[message.DbId].Content = _serializer.Serialize(message.Origin);
             return Task.CompletedTask;
         }
 
@@ -42,7 +41,6 @@ namespace DotNetCore.CAP.InMemoryStorage
         {
             ReceivedMessages[message.DbId].StatusName = state;
             ReceivedMessages[message.DbId].ExpiresAt = message.ExpiresAt;
-            ReceivedMessages[message.DbId].Content = _serializer.Serialize(message.Origin);
             return Task.CompletedTask;
         }
 

--- a/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
@@ -42,7 +42,6 @@ namespace DotNetCore.CAP.MongoDB
             var collection = _database.GetCollection<PublishedMessage>(_options.Value.PublishedCollection);
 
             var updateDef = Builders<PublishedMessage>.Update
-                .Set(x => x.Content, _serializer.Serialize(message.Origin))
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)
                 .Set(x => x.StatusName, state.ToString("G"));
@@ -55,7 +54,6 @@ namespace DotNetCore.CAP.MongoDB
             var collection = _database.GetCollection<ReceivedMessage>(_options.Value.ReceivedCollection);
 
             var updateDef = Builders<ReceivedMessage>.Update
-                .Set(x => x.Content, _serializer.Serialize(message.Origin))
                 .Set(x => x.Retries, message.Retries)
                 .Set(x => x.ExpiresAt, message.ExpiresAt)
                 .Set(x => x.StatusName, state.ToString("G"));

--- a/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
@@ -158,12 +158,12 @@ namespace DotNetCore.CAP.MySql
         private async Task ChangeMessageStateAsync(string tableName, MediumMessage message, StatusName state)
         {
             var sql =
-                $"UPDATE `{tableName}` SET `Content`=@Content,`Retries`=@Retries,`ExpiresAt`=@ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
+                $"UPDATE `{tableName}` SET `Retries`=@Retries,`ExpiresAt`=@ExpiresAt,`StatusName`=@StatusName WHERE `Id`=@Id;";
 
             object[] sqlParams =
             {
                 new MySqlParameter("@Id", message.DbId),
-                new MySqlParameter("@Content", _serializer.Serialize(message.Origin)),
+                //new MySqlParameter("@Content", _serializer.Serialize(message.Origin)),
                 new MySqlParameter("@Retries", message.Retries),
                 new MySqlParameter("@ExpiresAt", message.ExpiresAt),
                 new MySqlParameter("@StatusName", state.ToString("G"))

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -158,12 +158,11 @@ namespace DotNetCore.CAP.PostgreSql
         private async Task ChangeMessageStateAsync(string tableName, MediumMessage message, StatusName state)
         {
             var sql =
-                $"UPDATE {tableName} SET \"Content\"=@Content,\"Retries\"=@Retries,\"ExpiresAt\"=@ExpiresAt,\"StatusName\"=@StatusName WHERE \"Id\"=@Id";
+                $"UPDATE {tableName} SET \"Retries\"=@Retries,\"ExpiresAt\"=@ExpiresAt,\"StatusName\"=@StatusName WHERE \"Id\"=@Id";
 
             object[] sqlParams =
             {
                 new NpgsqlParameter("@Id", long.Parse(message.DbId)),
-                new NpgsqlParameter("@Content", _serializer.Serialize(message.Origin)),
                 new NpgsqlParameter("@Retries", message.Retries),
                 new NpgsqlParameter("@ExpiresAt", message.ExpiresAt),
                 new NpgsqlParameter("@StatusName", state.ToString("G"))

--- a/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
@@ -157,12 +157,11 @@ namespace DotNetCore.CAP.SqlServer
         private async Task ChangeMessageStateAsync(string tableName, MediumMessage message, StatusName state)
         {
             var sql =
-                $"UPDATE {tableName} SET Content=@Content, Retries=@Retries,ExpiresAt=@ExpiresAt,StatusName=@StatusName WHERE Id=@Id";
+                $"UPDATE {tableName} SET Retries=@Retries,ExpiresAt=@ExpiresAt,StatusName=@StatusName WHERE Id=@Id";
 
             object[] sqlParams =
             {
                 new SqlParameter("@Id", message.DbId),
-                new SqlParameter("@Content", _serializer.Serialize(message.Origin)),
                 new SqlParameter("@Retries", message.Retries),
                 new SqlParameter("@ExpiresAt", message.ExpiresAt),
                 new SqlParameter("@StatusName", state.ToString("G"))


### PR DESCRIPTION
If the subscription model is a reference type, the properties of the updated model will be saved to the database.
I don't think it is necessary. The important thing is that when RETRY, the content is not the original value.