### PR TITLE
Handling unobserved tasks of async method calls in Amazon SQS module and local development environment support

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
@@ -119,7 +119,7 @@ namespace DotNetCore.CAP.AmazonSQS
         {
             try
             {
-                var ret = _sqsClient.DeleteMessageAsync(_queueUrl, (string)sender).GetAwaiter().GetResult();
+                _ = _sqsClient.DeleteMessageAsync(_queueUrl, (string)sender).GetAwaiter().GetResult();
             }
             catch (InvalidIdFormatException ex)
             {
@@ -132,7 +132,7 @@ namespace DotNetCore.CAP.AmazonSQS
             try
             {
                 // Visible again in 3 seconds
-                var ret = _sqsClient.ChangeMessageVisibilityAsync(_queueUrl, (string)sender, 3).GetAwaiter().GetResult();
+                _ = _sqsClient.ChangeMessageVisibilityAsync(_queueUrl, (string)sender, 3).GetAwaiter().GetResult();
             }
             catch (MessageNotInflightException ex)
             {

--- a/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
@@ -119,7 +119,7 @@ namespace DotNetCore.CAP.AmazonSQS
         {
             try
             {
-                _sqsClient.DeleteMessageAsync(_queueUrl, (string)sender);
+                var ret = _sqsClient.DeleteMessageAsync(_queueUrl, (string)sender).GetAwaiter().GetResult();
             }
             catch (InvalidIdFormatException ex)
             {
@@ -132,7 +132,7 @@ namespace DotNetCore.CAP.AmazonSQS
             try
             {
                 // Visible again in 3 seconds
-                _sqsClient.ChangeMessageVisibilityAsync(_queueUrl, (string)sender, 3);
+                var ret = _sqsClient.ChangeMessageVisibilityAsync(_queueUrl, (string)sender, 3).GetAwaiter().GetResult();
             }
             catch (MessageNotInflightException ex)
             {
@@ -159,9 +159,18 @@ namespace DotNetCore.CAP.AmazonSQS
 
                 try
                 {
-                    _snsClient = _amazonSQSOptions.Credentials != null
-                        ? new AmazonSimpleNotificationServiceClient(_amazonSQSOptions.Credentials, _amazonSQSOptions.Region)
-                        : new AmazonSimpleNotificationServiceClient(_amazonSQSOptions.Region);
+                    if (string.IsNullOrWhiteSpace(_amazonSQSOptions.SNSServiceUrl))
+                    {
+                        _snsClient = _amazonSQSOptions.Credentials != null
+                            ? new AmazonSimpleNotificationServiceClient(_amazonSQSOptions.Credentials, _amazonSQSOptions.Region)
+                            : new AmazonSimpleNotificationServiceClient(_amazonSQSOptions.Region);
+                    }
+                    else
+                    {
+                        _snsClient = _amazonSQSOptions.Credentials != null
+                            ? new AmazonSimpleNotificationServiceClient(_amazonSQSOptions.Credentials, new AmazonSimpleNotificationServiceConfig() { ServiceURL = _amazonSQSOptions.SNSServiceUrl })
+                            : new AmazonSimpleNotificationServiceClient(new AmazonSimpleNotificationServiceConfig() { ServiceURL = _amazonSQSOptions.SNSServiceUrl });
+                    }
                 }
                 finally
                 {
@@ -175,10 +184,18 @@ namespace DotNetCore.CAP.AmazonSQS
 
                 try
                 {
-
-                    _sqsClient = _amazonSQSOptions.Credentials != null
-                        ? new AmazonSQSClient(_amazonSQSOptions.Credentials, _amazonSQSOptions.Region)
-                        : new AmazonSQSClient(_amazonSQSOptions.Region);
+                    if (string.IsNullOrWhiteSpace(_amazonSQSOptions.SQSServiceUrl))
+                    {
+                        _sqsClient = _amazonSQSOptions.Credentials != null
+                            ? new AmazonSQSClient(_amazonSQSOptions.Credentials, _amazonSQSOptions.Region)
+                            : new AmazonSQSClient(_amazonSQSOptions.Region);
+                    }
+                    else
+                    {
+                        _sqsClient = _amazonSQSOptions.Credentials != null
+                            ? new AmazonSQSClient(_amazonSQSOptions.Credentials, new AmazonSQSConfig() { ServiceURL = _amazonSQSOptions.SQSServiceUrl })
+                            : new AmazonSQSClient(new AmazonSQSConfig() { ServiceURL = _amazonSQSOptions.SQSServiceUrl });
+                    }
 
                     // If provide the name of an existing queue along with the exact names and values
                     // of all the queue's attributes, <code>CreateQueue</code> returns the queue URL for
@@ -194,7 +211,7 @@ namespace DotNetCore.CAP.AmazonSQS
 
         #region private methods
 
-        private Task InvalidIdFormatLog(string exceptionMessage)
+        private void InvalidIdFormatLog(string exceptionMessage)
         {
             var logArgs = new LogMessageEventArgs
             {
@@ -203,11 +220,9 @@ namespace DotNetCore.CAP.AmazonSQS
             };
 
             OnLog?.Invoke(null, logArgs);
-
-            return Task.CompletedTask;
         }
 
-        private Task MessageNotInflightLog(string exceptionMessage)
+        private void MessageNotInflightLog(string exceptionMessage)
         {
             var logArgs = new LogMessageEventArgs
             {
@@ -216,8 +231,6 @@ namespace DotNetCore.CAP.AmazonSQS
             };
 
             OnLog?.Invoke(null, logArgs);
-
-            return Task.CompletedTask;
         }
 
         private async Task GenerateSqsAccessPolicyAsync(IEnumerable<string> topicArns)

--- a/src/DotNetCore.CAP.AmazonSQS/CAP.AmazonSQSOptions.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/CAP.AmazonSQSOptions.cs
@@ -13,5 +13,16 @@ namespace DotNetCore.CAP
         public RegionEndpoint Region { get; set; }
 
         public AWSCredentials Credentials { get; set; }
+
+        /// <summary>
+        /// Overrides Service Url deduced from AWS Region. To use in local development environments like localstack.
+        /// </summary>
+        public string SNSServiceUrl { get; set; }
+
+        /// <summary>
+        /// Overrides Service Url deduced from AWS Region. To use in local development environments like localstack.
+        /// </summary>
+        public string SQSServiceUrl { get; set; }
+
     }
 }

--- a/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
@@ -31,7 +31,7 @@ namespace DotNetCore.CAP.AmazonSQS
             _sqsOptions = sqsOptions;
         }
 
-        public BrokerAddress BrokerAddress => new BrokerAddress("RabbitMQ", string.Empty);
+        public BrokerAddress BrokerAddress => new BrokerAddress("AmazonSQS", string.Empty);
 
         public async Task<OperateResult> SendAsync(TransportMessage message)
         {
@@ -100,9 +100,18 @@ namespace DotNetCore.CAP.AmazonSQS
 
             try
             {
-                _snsClient = _sqsOptions.Value.Credentials != null
-                    ? new AmazonSimpleNotificationServiceClient(_sqsOptions.Value.Credentials, _sqsOptions.Value.Region)
-                    : new AmazonSimpleNotificationServiceClient(_sqsOptions.Value.Region);
+                if (string.IsNullOrWhiteSpace(_sqsOptions.Value.SNSServiceUrl))
+                {
+                    _snsClient = _sqsOptions.Value.Credentials != null
+                        ? new AmazonSimpleNotificationServiceClient(_sqsOptions.Value.Credentials, _sqsOptions.Value.Region)
+                        : new AmazonSimpleNotificationServiceClient(_sqsOptions.Value.Region);
+                }
+                else
+                {
+                    _snsClient = _sqsOptions.Value.Credentials != null
+                        ? new AmazonSimpleNotificationServiceClient(_sqsOptions.Value.Credentials, new AmazonSimpleNotificationServiceConfig() { ServiceURL = _sqsOptions.Value.SNSServiceUrl })
+                        : new AmazonSimpleNotificationServiceClient(new AmazonSimpleNotificationServiceConfig() { ServiceURL = _sqsOptions.Value.SNSServiceUrl });
+                }
 
                 if (_topicArnMaps == null)
                 {


### PR DESCRIPTION
I had to work on local development environment, didn't test on AWS.

This PR is about #1029 

Also added serviceUrl parameters to Amazon SQS module configuration to support local development environments. If provided, these service url parameters override AWS region settings.

Example usage for localstack:
```
                        opts.UseAmazonSQS(conf =>
                        {
                            conf.SNSServiceUrl = "http://localhost:4566";
                            conf.SQSServiceUrl = "http://localhost:4566";
                            conf.Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test");
                        });

```