### PR TITLE
Added possibility to process messages for each consumer group independently

### DIFF
--- a/CAP.sln
+++ b/CAP.sln
@@ -82,6 +82,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.Pulsar", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Pulsar.InMemory", "samples\Sample.Pulsar.InMemory\Sample.Pulsar.InMemory.csproj", "{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.RabbitMQ.SqlServer.DispatcherPerGroup", "samples\Sample.RabbitMQ.SqlServer.DispatcherPerGroup\Sample.RabbitMQ.SqlServer.DispatcherPerGroup.csproj", "{DCDF58E8-F823-4F04-9F8C-E8076DC16A68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -196,6 +198,10 @@ Global
 		{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -228,6 +234,7 @@ Global
 		{23684403-7DA8-489A-8A1E-8056D7683E18} = {C09CDAB0-6DD4-46E9-B7F3-3EF2A4741EA0}
 		{AB7A10CB-2C7E-49CE-AA21-893772FF6546} = {9B2AE124-6636-4DE9-83A3-70360DABD0C4}
 		{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5} = {3A6B6931-A123-477A-9469-8B468B5385AF}
+		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E70565D-94CF-40B4-BFE1-AC18D5F736AB}

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ public void ShowTime2(DateTime datetime)
 }
 
 ```
-`ShowTime1` and `ShowTime2` will be called at the same time.
+`ShowTime1` and `ShowTime2` will be called one after another because all received messages are processed linear.
+You can change that behaviour increasing `ConsumerThreadCount`.
 
 BTW, You can specify the default group name in the configuration:
 

--- a/docs/content/user-guide/en/cap/configuration.md
+++ b/docs/content/user-guide/en/cap/configuration.md
@@ -93,7 +93,7 @@ The interval of the collector processor deletes expired messages.
 
 #### ConsumerThreadCount 
 
-> Default : 1
+> Default: 1
 
 Number of consumer threads, when this value is greater than 1, the order of message execution cannot be guaranteed.
 
@@ -116,3 +116,9 @@ Failure threshold callback. This action is called when the retry reaches the val
 > Default: 24*3600 sec (1 days)
 
 The expiration time (in seconds) of the success message. When the message is sent or consumed successfully, it will be removed from database storage when the time reaches `SucceedMessageExpiredAfter` seconds. You can set the expiration time by specifying this value.
+
+#### UseDispatchingPerGroup
+
+> Default: false
+
+If `true` then all consumers within the same group pushes received messages to own dispatching pipeline channel. Each channel has set thread count to `ConsumerThreadCount` value.

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Controllers/HomeController.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Controllers/HomeController.cs
@@ -1,0 +1,35 @@
+using DotNetCore.CAP;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages;
+using System;
+using System.Threading.Tasks;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Controllers
+{
+    public class HomeController : Controller
+    {
+        private readonly ICapPublisher _capPublisher;
+
+        public HomeController(ICapPublisher capPublisher)
+        {
+            _capPublisher = capPublisher;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            await using (var connection = new SqlConnection("Server=(local);Database=CAP-Test;Trusted_Connection=True;"))
+            {
+                using var transaction = connection.BeginTransaction(_capPublisher);
+                // This is where you would do other work that is going to persist data to your database
+
+                var message = TestMessage.Create($"This is message text created at {DateTime.Now:O}.");
+
+                await _capPublisher.PublishAsync(typeof(TestMessage).FullName, message);
+                transaction.Commit();
+            }
+
+            return Content("ok");
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/FastProcessingReceiver.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/FastProcessingReceiver.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
+{
+    [QueueHandlerTopic("fasttopic")]
+    public class FastProcessingReceiver : QueueHandler
+    {
+        private readonly ILogger<FastProcessingReceiver> _logger;
+
+        public FastProcessingReceiver(ILogger<FastProcessingReceiver> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task Handle(TestMessage value)
+        {
+            _logger.LogInformation($"Starting FAST processing handler {DateTime.Now:O}: {value.Text}");
+            await Task.Delay(200);
+            _logger.LogInformation($"Ending   FAST processing handler {DateTime.Now:O}: {value.Text}");
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/SlowProcessingReceiver.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/SlowProcessingReceiver.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
+{
+    [QueueHandlerTopic("slowtopic")]
+    public class SlowProcessingReceiver : QueueHandler
+    {
+        private readonly ILogger<SlowProcessingReceiver> _logger;
+
+        public SlowProcessingReceiver(ILogger<SlowProcessingReceiver> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task Handle(TestMessage value)
+        {
+            _logger.LogInformation($"Starting SLOW processing handler {DateTime.Now:O}: {value.Text}");
+            await Task.Delay(10000);
+            _logger.LogInformation($"Ending   SLOW processing handler {DateTime.Now:O}: {value.Text}");
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/TestMessage.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/TestMessage.cs
@@ -1,0 +1,12 @@
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
+{
+    public class TestMessage
+    {
+        public static TestMessage Create(string text) => new()
+        {
+            Text = text
+        };
+
+        public string Text { get; private init; }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/VeryFastProcessingReceiver.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/VeryFastProcessingReceiver.cs
@@ -6,11 +6,11 @@ using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers;
 namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
 {
     [QueueHandlerTopic("fasttopic")]
-    public class FastProcessingReceiver : QueueHandler
+    public class VeryFastProcessingReceiver : QueueHandler
     {
-        private readonly ILogger<FastProcessingReceiver> _logger;
+        private readonly ILogger<VeryFastProcessingReceiver> _logger;
 
-        public FastProcessingReceiver(ILogger<FastProcessingReceiver> logger)
+        public VeryFastProcessingReceiver(ILogger<VeryFastProcessingReceiver> logger)
         {
             _logger = logger;
         }
@@ -18,7 +18,7 @@ namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
         public async Task Handle(TestMessage value)
         {
             _logger.LogInformation($"Starting FAST processing handler {DateTime.Now:O}: {value.Text}");
-            await Task.Delay(200);
+            await Task.Delay(50);
             _logger.LogInformation($"Ending   FAST processing handler {DateTime.Now:O}: {value.Text}");
         }
     }

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/XSlowProcessingReceiver.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Messages/XSlowProcessingReceiver.cs
@@ -6,11 +6,11 @@ using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers;
 namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.Messages
 {
     [QueueHandlerTopic("slowtopic")]
-    public class SlowProcessingReceiver : QueueHandler
+    public class XSlowProcessingReceiver : QueueHandler
     {
-        private readonly ILogger<SlowProcessingReceiver> _logger;
+        private readonly ILogger<XSlowProcessingReceiver> _logger;
 
-        public SlowProcessingReceiver(ILogger<SlowProcessingReceiver> logger)
+        public XSlowProcessingReceiver(ILogger<XSlowProcessingReceiver> logger)
         {
             _logger = logger;
         }

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Program.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Program.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using System;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .WriteTo.Debug()
+#if DEBUG
+                .WriteTo.Seq("http://localhost:5341")
+#endif
+                .CreateLogger();
+
+            try
+            {
+                Log.Information("Starting host...");
+                CreateHostBuilder(args).Build().Run();
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex.InnerException ?? ex, "Host terminated unexpectedly");
+                return 1;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, builder) =>
+                {
+                    builder
+                        .AddJsonFile("appsettings.json")
+                        .AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", true);
+                })
+                .UseSerilog((context, configuration) =>
+                {
+                    configuration.ReadFrom.Configuration(context.Configuration);
+                }, true, true)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Sample.RabbitMQ.SqlServer.DispatcherPerGroup.csproj
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Sample.RabbitMQ.SqlServer.DispatcherPerGroup.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
+
+        <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.1" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetCore.CAP.Dashboard\DotNetCore.CAP.Dashboard.csproj" />
+    <ProjectReference Include="..\..\src\DotNetCore.CAP.RabbitMQ\DotNetCore.CAP.RabbitMQ.csproj" />
+    <ProjectReference Include="..\..\src\DotNetCore.CAP.SqlServer\DotNetCore.CAP.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\DotNetCore.CAP\DotNetCore.CAP.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Startup.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/Startup.cs
@@ -1,0 +1,52 @@
+using DotNetCore.CAP;
+using DotNetCore.CAP.Internal;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers;
+using Serilog;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddLogging(x => x.AddSerilog());
+
+            services
+                .AddSingleton<IConsumerServiceSelector, TypedConsumerServiceSelector>()
+                .AddQueueHandlers(typeof(Startup).Assembly);
+
+            services.AddCap(options =>
+            {
+                options.UseSqlServer("Server=(local);Database=CAP-Test;Trusted_Connection=True;");
+                options.UseRabbitMQ("localhost");
+                options.UseDashboard();
+                options.GroupNamePrefix = "th";
+                options.ConsumerThreadCount = 1;
+
+                options.UseDispatchingPerGroup = true;
+            });
+
+            services.AddControllersWithViews();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseDeveloperExceptionPage();
+            app.UseSerilogRequestLogging();
+            app.UseCapDashboard();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandler.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandler.cs
@@ -1,0 +1,4 @@
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers
+{
+    public abstract class QueueHandler { }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandlerTopicAttribute.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandlerTopicAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class QueueHandlerTopicAttribute : Attribute
+    {
+        public string Topic { get; }
+
+        public QueueHandlerTopicAttribute(string topic)
+        {
+            Topic = topic;
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandlersExtensions.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/QueueHandlersExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers
+{
+    internal static class QueueHandlersExtensions
+    {
+        private static readonly Type queueHandlerType = typeof(QueueHandler);
+
+        public static IServiceCollection AddQueueHandlers(this IServiceCollection services, params Assembly[] assemblies)
+        {
+            assemblies ??= new[] { Assembly.GetEntryAssembly() };
+
+            foreach (var type in assemblies.Distinct().SelectMany(x => x.GetTypes().Where(FilterHandlers)))
+            {
+                services.AddTransient(queueHandlerType, type);
+            }
+
+            return services;
+        }
+
+        private static bool FilterHandlers(Type t)
+        {
+            var topic = t.GetCustomAttribute<QueueHandlerTopicAttribute>();
+
+            return queueHandlerType.IsAssignableFrom(t) && topic != null && t.IsClass && !t.IsAbstract;
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/TypedConsumerServiceSelector.cs
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/TypedConsumers/TypedConsumerServiceSelector.cs
@@ -1,0 +1,87 @@
+using DotNetCore.CAP;
+using DotNetCore.CAP.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Sample.RabbitMQ.SqlServer.DispatcherPerGroup.TypedConsumers
+{
+    internal class TypedConsumerServiceSelector : ConsumerServiceSelector
+    {
+        private readonly CapOptions _capOptions;
+
+        public TypedConsumerServiceSelector(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            _capOptions = serviceProvider.GetRequiredService<IOptions<CapOptions>>().Value;
+        }
+
+        protected override IEnumerable<ConsumerExecutorDescriptor> FindConsumersFromInterfaceTypes(IServiceProvider provider)
+        {
+            var executorDescriptorList = new List<ConsumerExecutorDescriptor>(30);
+
+            using var scoped = provider.CreateScope();
+            var consumerServices = scoped.ServiceProvider.GetServices<QueueHandler>();
+            foreach (var service in consumerServices)
+            {
+                var typeInfo = service.GetType().GetTypeInfo();
+                if (!typeof(QueueHandler).GetTypeInfo().IsAssignableFrom(typeInfo))
+                {
+                    continue;
+                }
+
+                executorDescriptorList.AddRange(GetMyDescription(typeInfo));
+            }
+
+            return executorDescriptorList;
+        }
+
+        private IEnumerable<ConsumerExecutorDescriptor> GetMyDescription(TypeInfo typeInfo)
+        {
+            var method = typeInfo.DeclaredMethods.FirstOrDefault(x => x.Name == "Handle");
+            if (method == null) yield break;
+
+            var topicAttr = typeInfo.GetCustomAttributes<QueueHandlerTopicAttribute>(true);
+            var topicAttributes = topicAttr as IList<QueueHandlerTopicAttribute> ?? topicAttr.ToList();
+
+            if (topicAttributes.Count == 0) yield break;
+
+            foreach (var attr in topicAttributes)
+            {
+                var topic = attr.Topic == null
+                    ? _capOptions.DefaultGroupName + "." + _capOptions.Version
+                    : attr.Topic + "." + _capOptions.Version;
+
+                if (!string.IsNullOrEmpty(_capOptions.GroupNamePrefix))
+                {
+                    topic = $"{_capOptions.GroupNamePrefix}.{topic}";
+                }
+
+                var parameters = method.GetParameters().Select(p => new ParameterDescriptor
+                {
+                    Name = p.Name,
+                    ParameterType = p.ParameterType,
+                    IsFromCap = p.GetCustomAttributes(typeof(FromCapAttribute)).Any()
+                }).ToList();
+
+                var capName = parameters.FirstOrDefault(x => !x.IsFromCap)?.ParameterType.FullName;
+                if (string.IsNullOrEmpty(capName)) continue;
+
+                yield return new ConsumerExecutorDescriptor
+                {
+                    Attribute = new CapSubscribeAttribute(capName)
+                    {
+                        Group = topic
+                    },
+                    Parameters = parameters,
+                    MethodInfo = method,
+                    ImplTypeInfo = typeInfo,
+                    TopicNamePrefix = _capOptions.TopicNamePrefix,
+                    ServiceTypeInfo = typeInfo
+                };
+            }
+        }
+    }
+}

--- a/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/appsettings.json
+++ b/samples/Sample.RabbitMQ.SqlServer.DispatcherPerGroup/appsettings.json
@@ -1,0 +1,10 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*"
+}

--- a/src/DotNetCore.CAP/CAP.Builder.cs
+++ b/src/DotNetCore.CAP/CAP.Builder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using DotNetCore.CAP.Filter;
 using DotNetCore.CAP.Internal;
+using DotNetCore.CAP.Processor;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -27,6 +27,7 @@ namespace DotNetCore.CAP
             Version = "v1";
             DefaultGroupName = "cap.queue." + Assembly.GetEntryAssembly()?.GetName().Name.ToLower();
             CollectorCleaningInterval = 300;
+            UseDispatchingPerGroup = false;
         }
 
         internal IList<ICapOptionsExtension> Extensions { get; }
@@ -79,6 +80,12 @@ namespace DotNetCore.CAP
         /// Default is 1
         /// </summary>
         public int ConsumerThreadCount { get; set; }
+
+        /// <summary>
+        /// If true then each message group will have own independent dispatching pipeline. Each pipeline use as many threads as <see cref="ConsumerThreadCount"/> value is.
+        /// Default is false.
+        /// </summary>
+        public bool UseDispatchingPerGroup { get; set; }
 
         /// <summary>
         /// The number of producer thread connections.

--- a/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
+++ b/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
@@ -51,9 +51,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<TransportCheckProcessor>();
             services.TryAddSingleton<CollectorProcessor>();
 
-            //Sender and Executors
+            //Sender
             services.TryAddSingleton<IMessageSender, MessageSender>();
-            services.TryAddSingleton<IDispatcher, Dispatcher>();
 
             services.TryAddSingleton<ISerializer, JsonUtf8Serializer>();
 
@@ -63,6 +62,17 @@ namespace Microsoft.Extensions.DependencyInjection
             //Options and extension service
             var options = new CapOptions();
             setupAction(options);
+
+            //Executors
+            if (options.UseDispatchingPerGroup)
+            {
+                services.TryAddSingleton<IDispatcher, DispatcherPerGroup>();
+            }
+            else
+            {
+                services.TryAddSingleton<IDispatcher, Dispatcher>();
+            }
+
             foreach (var serviceExtension in options.Extensions)
             {
                 serviceExtension.AddServices(services);

--- a/src/DotNetCore.CAP/Internal/LoggerExtensions.cs
+++ b/src/DotNetCore.CAP/Internal/LoggerExtensions.cs
@@ -45,14 +45,14 @@ namespace DotNetCore.CAP.Internal
             logger.LogError(ex, $"An exception occured while publishing a message, reason:{reason}. message id:{messageId}");
         }
 
-        public static void ConsumerExecuting(this ILogger logger, string methodName)
+        public static void ConsumerExecuting(this ILogger logger, string className, string methodName, string group)
         {
-            logger.LogInformation($"Executing subscriber method '{methodName}'");
+            logger.LogInformation($"Executing subscriber method '{className}.{methodName}' on group '{group}'");
         }
 
-        public static void ConsumerExecuted(this ILogger logger, string methodName, double milliseconds)
+        public static void ConsumerExecuted(this ILogger logger, string className, string methodName, string group, double milliseconds)
         {
-            logger.LogInformation($"Executed subscriber method '{methodName}' in {milliseconds} ms");
+            logger.LogInformation($"Executed subscriber method '{className}.{methodName}' on group '{group}' in {milliseconds} ms");
         }
 
         public static void ServerStarting(this ILogger logger)

--- a/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -15,7 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.Processor
 {
-    public class Dispatcher : IDispatcher
+    public class DispatcherPerGroup : IDispatcher
     {
         private readonly IMessageSender _sender;
         private readonly CapOptions _options;
@@ -24,9 +25,12 @@ namespace DotNetCore.CAP.Processor
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
         private Channel<MediumMessage> _publishedChannel;
-        private Channel<(MediumMessage, ConsumerExecutorDescriptor)> _receivedChannel;
+        // private Channel<(MediumMessage, ConsumerExecutorDescriptor)> _receivedChannel;
+        private ConcurrentDictionary<string, Channel<(MediumMessage, ConsumerExecutorDescriptor)>> _receivedChannels;
+        private CancellationToken _stoppingToken;
 
-        public Dispatcher(ILogger<Dispatcher> logger,
+        public DispatcherPerGroup(
+            ILogger<Dispatcher> logger,
             IMessageSender sender,
             IOptions<CapOptions> options,
             ISubscribeDispatcher executor)
@@ -39,8 +43,9 @@ namespace DotNetCore.CAP.Processor
 
         public void Start(CancellationToken stoppingToken)
         {
-            stoppingToken.ThrowIfCancellationRequested();
-            stoppingToken.Register(() => _cts.Cancel()); 
+            _stoppingToken = stoppingToken;
+            _stoppingToken.ThrowIfCancellationRequested();
+            _stoppingToken.Register(() => _cts.Cancel());
 
             var capacity = _options.ProducerThreadCount * 500;
             _publishedChannel = Channel.CreateBounded<MediumMessage>(new BoundedChannelOptions(capacity > 5000 ? 5000 : capacity)
@@ -51,23 +56,13 @@ namespace DotNetCore.CAP.Processor
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-            capacity = _options.ConsumerThreadCount * 300;
-            _receivedChannel = Channel.CreateBounded<(MediumMessage, ConsumerExecutorDescriptor)>(new BoundedChannelOptions(capacity > 3000 ? 3000 : capacity)
-            {
-                AllowSynchronousContinuations = true,
-                SingleReader = _options.ConsumerThreadCount == 1,
-                SingleWriter = true,
-                FullMode = BoundedChannelFullMode.Wait
-            });
-
-
             Task.WhenAll(Enumerable.Range(0, _options.ProducerThreadCount)
                 .Select(_ => Task.Factory.StartNew(() => Sending(stoppingToken), stoppingToken, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());
 
-            Task.WhenAll(Enumerable.Range(0, _options.ConsumerThreadCount)
-                .Select(_ => Task.Factory.StartNew(() => Processing(stoppingToken), stoppingToken, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());
+            _receivedChannels = new ConcurrentDictionary<string, Channel<(MediumMessage, ConsumerExecutorDescriptor)>>(_options.ConsumerThreadCount, _options.ConsumerThreadCount * 2);
+            GetOrCreateReceiverChannel(_options.DefaultGroupName);
 
-            _logger.LogInformation("Starting default Dispatcher");
+            _logger.LogInformation("Starting DispatcherPerGroup");
         }
 
         public void EnqueueToPublish(MediumMessage message)
@@ -95,11 +90,20 @@ namespace DotNetCore.CAP.Processor
         {
             try
             {
-                if (!_receivedChannel.Writer.TryWrite((message, descriptor)))
+                var group = descriptor.Attribute.Group ?? _options.DefaultGroupName;
+
+                if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    while (_receivedChannel.Writer.WaitToWriteAsync(_cts.Token).AsTask().ConfigureAwait(false).GetAwaiter().GetResult())
+                    _logger.LogDebug("Enqueue message for group {ConsumerGroup}", group);
+                }
+
+                var channel = GetOrCreateReceiverChannel(group);
+
+                if (!channel.Writer.TryWrite((message, descriptor)))
+                {
+                    while (channel.Writer.WaitToWriteAsync(_cts.Token).AsTask().ConfigureAwait(false).GetAwaiter().GetResult())
                     {
-                        if (_receivedChannel.Writer.TryWrite((message, descriptor)))
+                        if (channel.Writer.TryWrite((message, descriptor)))
                         {
                             return;
                         }
@@ -110,6 +114,28 @@ namespace DotNetCore.CAP.Processor
             {
                 //Ignore
             }
+        }
+
+        private Channel<(MediumMessage, ConsumerExecutorDescriptor)> GetOrCreateReceiverChannel(string key)
+        {
+            return _receivedChannels.GetOrAdd(key, group =>
+            {
+                _logger.LogInformation("Creating receiver channel for group {ConsumerGroup} with thread count {ConsumerThreadCount}", group, _options.ConsumerThreadCount);
+
+                var capacity = _options.ConsumerThreadCount * 300;
+                var channel = Channel.CreateBounded<(MediumMessage, ConsumerExecutorDescriptor)>(new BoundedChannelOptions(capacity > 3000 ? 3000 : capacity)
+                {
+                    AllowSynchronousContinuations = true,
+                    SingleReader = _options.ConsumerThreadCount == 1,
+                    SingleWriter = true,
+                    FullMode = BoundedChannelFullMode.Wait
+                });
+
+                Task.WhenAll(Enumerable.Range(0, _options.ConsumerThreadCount)
+                    .Select(_ => Task.Factory.StartNew(() => Processing(group, channel, _stoppingToken), _stoppingToken, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());
+
+                return channel;
+            });
         }
 
         private async Task Sending(CancellationToken cancellationToken)
@@ -125,14 +151,15 @@ namespace DotNetCore.CAP.Processor
                             var result = await _sender.SendAsync(message);
                             if (!result.Succeeded)
                             {
-                                _logger.MessagePublishException(message.Origin.GetId(), result.ToString(),
+                                _logger.MessagePublishException(
+                                    message.Origin.GetId(),
+                                    result.ToString(),
                                     result.Exception);
                             }
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogError(ex,
-                                $"An exception occurred when sending a message to the MQ. Id:{message.DbId}");
+                            _logger.LogError(ex, $"An exception occurred when sending a message to the MQ. Id:{message.DbId}");
                         }
                     }
                 }
@@ -143,16 +170,21 @@ namespace DotNetCore.CAP.Processor
             }
         }
 
-        private async Task Processing(CancellationToken cancellationToken)
+        private async Task Processing(string group, Channel<(MediumMessage, ConsumerExecutorDescriptor)> channel, CancellationToken cancellationToken)
         {
             try
             {
-                while (await _receivedChannel.Reader.WaitToReadAsync(cancellationToken))
+                while (await channel.Reader.WaitToReadAsync(cancellationToken))
                 {
-                    while (_receivedChannel.Reader.TryRead(out var message))
+                    while (channel.Reader.TryRead(out var message))
                     {
                         try
                         {
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug("Dispatching message for group {ConsumerGroup}", group);
+                            }
+
                             await _executor.DispatchAsync(message.Item1, message.Item2, cancellationToken);
                         }
                         catch (OperationCanceledException)
@@ -161,8 +193,7 @@ namespace DotNetCore.CAP.Processor
                         }
                         catch (Exception e)
                         {
-                            _logger.LogError(e,
-                                $"An exception occurred when invoke subscriber. MessageId:{message.Item1.DbId}");
+                            _logger.LogError(e, $"An exception occurred when invoke subscriber. MessageId:{message.Item1.DbId}");
                         }
                     }
                 }

--- a/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.Processor
 {
-    public class DispatcherPerGroup : IDispatcher
+    internal class DispatcherPerGroup : IDispatcher
     {
         private readonly IMessageSender _sender;
         private readonly CapOptions _options;


### PR DESCRIPTION
This addition do not change anything to default behavior of CAP.

To run processing messages for each consumer group independently must set option `UseDispatchingPerGroup` to `true`. This will add to DI container `DispatcherPerGroup` instead of default `Dispatcher`.

With default `Dispatcher` behavior of CAP is:

![dispatcher default](https://user-images.githubusercontent.com/147718/140322091-a28c1d16-3ab7-4f56-bc6e-eeb664694915.png)

As you can see `VeryFastProcessingReceiver` waits until `XSlowProcessingReceiver` finishes.

With `DispatcherPerGroup` behavior of CAP is:

![dispatcher pergroup](https://user-images.githubusercontent.com/147718/140322457-66db64e2-0983-465e-b5cf-c12deda9bb17.png)

Here we have situation where all subscribers pushes received messages to own dispatching channel. Each channel has set thread count to `ConsumerThreadCount` value.

New feature is used in new sample application `Sample.RabbitMQ.SqlServer.DispatcherPerGroup`.