### PR TITLE
Fix bug: Dashboard not show message list

### DIFF
--- a/src/DotNetCore.CAP.SqlServer/IDbConnection.Extensions.cs
+++ b/src/DotNetCore.CAP.SqlServer/IDbConnection.Extensions.cs
@@ -56,7 +56,7 @@ namespace DotNetCore.CAP.SqlServer
             {
                 result = readerFunc(reader);
             }
-
+            command.Parameters.Clear();
             return result;
         }
 
@@ -91,7 +91,7 @@ namespace DotNetCore.CAP.SqlServer
                     result = (T)Convert.ChangeType(objValue, returnType);
                 }
             }
-
+            command.Parameters.Clear();
             return result;
         }
     }


### PR DESCRIPTION
Fix the bug that the dashboard (useSQLServer) doesn't show the message list, with error : the sqlparameter is already contained by another sqlparametercollection 
The cause is due to the reusing the sqlparam in SqlServerMonitoringApi.cs and the DbConnectionExtensions helper doesn't clear up command.param in every call.