### PR TITLE
Add Exception Details

### DIFF
--- a/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
@@ -206,6 +206,7 @@ namespace DotNetCore.CAP.Internal
                     catch (Exception e)
                     {
                         transportMessage.Headers[Headers.Exception] = e.GetType().Name + "-->" + e.Message;
+                        transportMessage.Headers[Headers.ExceptionDetails] = e.ToString();
                         string? dataUri;
                         if (transportMessage.Headers.TryGetValue(Headers.Type, out var val))
                         {

--- a/src/DotNetCore.CAP/Messages/Headers.cs
+++ b/src/DotNetCore.CAP/Messages/Headers.cs
@@ -28,5 +28,7 @@ namespace DotNetCore.CAP.Messages
         public const string SentTime = "cap-senttime";
 
         public const string Exception = "cap-exception";
+        
+        public const string ExceptionDetails = "cap-exception-details";
     }
 }

--- a/src/DotNetCore.CAP/Messages/Message.cs
+++ b/src/DotNetCore.CAP/Messages/Message.cs
@@ -72,11 +72,13 @@ namespace DotNetCore.CAP.Messages
             var msg = $"{ex.GetType().Name}-->{ex.Message}";
 
             message.Headers[Headers.Exception] = msg;
+            message.Headers[Headers.ExceptionDetails] = ex.ToString();
         }
 
         public static void RemoveException(this Message message)
         {
             message.Headers.Remove(Headers.Exception);
+            message.Headers.Remove(Headers.ExceptionDetails);
         }
     }
 }


### PR DESCRIPTION
Hello,

Currently, `cap-exception` header does not include the exception stack trace, which would be useful. So, I suggest adding another header called `cap-exception-details` which holds `exception.ToString()`.