### PR TITLE
CapSubscribeAttribute ctor support type

### DIFF
--- a/src/DotNetCore.CAP/CAP.Attribute.cs
+++ b/src/DotNetCore.CAP/CAP.Attribute.cs
@@ -17,6 +17,10 @@ namespace DotNetCore.CAP
 
         }
 
+        public CapSubscribeAttribute(Type type, bool isPartial = false) : base(type.FullName.ToLowerInvariant(), isPartial)
+        {
+        }
+
         public override string ToString()
         {
             return Name;


### PR DESCRIPTION
订阅特性构造函数添加类型支持，这样在使用时可以显式体现发布订阅的关联。

```csharp
[CapSubscribe(typeof(ReceivedMessage))]
public void CheckReceivedMessage(ReceivedMessage message)
{
    //business logic
}

public class ReceivedMessage
{
}
```