### PR TITLE
Publish and subscribe support for specified topic types

### DIFF
--- a/src/DotNetCore.CAP/CAP.Attribute.cs
+++ b/src/DotNetCore.CAP/CAP.Attribute.cs
@@ -17,6 +17,10 @@ namespace DotNetCore.CAP
 
         }
 
+        public CapSubscribeAttribute(Type type, bool isPartial = false) : base(type.FullName.ToLowerInvariant(), isPartial)
+        {
+        }
+
         public override string ToString()
         {
             return Name;

--- a/src/DotNetCore.CAP/CAP.Attribute.cs
+++ b/src/DotNetCore.CAP/CAP.Attribute.cs
@@ -17,7 +17,7 @@ namespace DotNetCore.CAP
 
         }
 
-        public CapSubscribeAttribute(Type type, bool isPartial = false) : base(type.FullName.ToLowerInvariant(), isPartial)
+        public CapSubscribeAttribute(Type type, bool isPartial = false) : base(CapPublisher.TypeToTopicName(type), isPartial)
         {
         }
 
@@ -30,7 +30,7 @@ namespace DotNetCore.CAP
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromCapAttribute : Attribute
     {
-       
+
     }
 
     public class CapHeader : ReadOnlyDictionary<string, string?>

--- a/src/DotNetCore.CAP/ICapPublisher.cs
+++ b/src/DotNetCore.CAP/ICapPublisher.cs
@@ -40,6 +40,24 @@ namespace DotNetCore.CAP
         Task PublishAsync<T>(string name, T? contentObj, IDictionary<string, string?> headers, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Asynchronous publish an object message with the specified topic type.
+        /// </summary>
+        /// <typeparam name="T">the topic type. (use the type full name to be topic name)</typeparam>
+        /// <param name="contentObj">message body content, that will be serialized. (can be null)</param>
+        /// <param name="callbackName">callback subscriber name</param>
+        /// <param name="cancellationToken"></param>
+        Task PublishAsync<T>(object? contentObj, string? callbackName = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronous publish an object message with the specified topic type.
+        /// </summary>
+        /// <typeparam name="T">the topic type. (use the type full name to be topic name)</typeparam>
+        /// <param name="contentObj">message body content, that will be serialized. (can be null)</param>
+        /// <param name="headers">message additional headers.</param>
+        /// <param name="cancellationToken"></param>
+        Task PublishAsync<T>(object? contentObj, IDictionary<string, string?> headers, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Publish an object message.
         /// </summary>
         /// <param name="name">the topic name or exchange router key.</param>
@@ -54,5 +72,21 @@ namespace DotNetCore.CAP
         /// <param name="contentObj">message body content, that will be serialized. (can be null)</param>
         /// <param name="headers">message additional headers.</param>
         void Publish<T>(string name, T? contentObj, IDictionary<string, string?> headers);
+
+        /// <summary>
+        /// Publish an object message with the specified topic type.
+        /// </summary>
+        /// <typeparam name="T">the topic type. (use the type full name to be topic name)</typeparam>
+        /// <param name="contentObj">message body content, that will be serialized. (can be null)</param>
+        /// <param name="callbackName">callback subscriber name</param>
+        void Publish<T>(object? contentObj, string? callbackName = null);
+
+        /// <summary>
+        /// Publish an object message with the specified topic type.
+        /// </summary>
+        /// <typeparam name="T">the topic type. (use the type full name to be topic name)</typeparam>
+        /// <param name="contentObj">message body content, that will be serialized. (can be null)</param>
+        /// <param name="headers">message additional headers.</param>
+        void Pulish<T>(object? contentObj, IDictionary<string, string?> headers);
     }
 }

--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -37,6 +37,16 @@ namespace DotNetCore.CAP.Internal
 
         public AsyncLocal<ICapTransaction> Transaction { get; }
 
+        public Task PublishAsync<T>(object? contentObj, string? callbackName = null, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => Publish(TypeToTopicName(typeof(T)), contentObj, callbackName), cancellationToken);
+        }
+
+        public Task PublishAsync<T>(object? contentObj, IDictionary<string, string?> headers, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => Publish(TypeToTopicName(typeof(T)), contentObj, headers), cancellationToken);
+        }
+
         public Task PublishAsync<T>(string name, T? value, IDictionary<string, string?> headers, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => Publish(name, value, headers), cancellationToken);
@@ -46,6 +56,16 @@ namespace DotNetCore.CAP.Internal
             CancellationToken cancellationToken = default)
         {
             return Task.Run(() => Publish(name, value, callbackName), cancellationToken);
+        }
+
+        public void Publish<T>(object? contentObj, string? callbackName = null)
+        {
+            Publish(TypeToTopicName(typeof(T)), contentObj, callbackName);
+        }
+
+        public void Pulish<T>(object? contentObj, IDictionary<string, string?> headers)
+        {
+            Publish(TypeToTopicName(typeof(T)), contentObj, headers);
         }
 
         public void Publish<T>(string name, T? value, string? callbackName = null)
@@ -122,6 +142,16 @@ namespace DotNetCore.CAP.Internal
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Convert type to topic name
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        internal static string TypeToTopicName(Type type)
+        {
+            return type.FullName.ToLowerInvariant();
         }
 
         #region tracing

--- a/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
+++ b/test/DotNetCore.CAP.Test/CAP.BuilderTest.cs
@@ -76,6 +76,26 @@ namespace DotNetCore.CAP.Test
             {
                 throw new NotImplementedException();
             }
+
+            public Task PublishAsync<T>(object contentObj, string callbackName = null, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task PublishAsync<T>(object contentObj, IDictionary<string, string> headers, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Publish<T>(object contentObj, string callbackName = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Pulish<T>(object contentObj, IDictionary<string, string> headers)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
Easier way to publish/subscribe.

//Eg:
```csharp
public class PublishController : Controller
{
    private readonly ICapPublisher _capBus;

    public PublishController(ICapPublisher capPublisher)
    {
        _capBus = capPublisher;
    }

    [Route("~/simple_publish")]
    public IActionResult SimplePublish()
    {
        //your business logic code

        _capBus.Publish<TopicType>(DateTime.Now);

        return Ok();
    }

    [NonAction]
    [CapSubscribe(typeof(TopicType))]
    public void CheckReceivedMessage(DateTime datetime)
    {
        Console.WriteLine(datetime);
    }
}

public class TopicType
{
}
```