### PR TITLE
Fixes MongoDB queries not returning results when a element convention name is registered

### DIFF
--- a/samples/Sample.RabbitMQ.MongoDB/docker-compose.yml
+++ b/samples/Sample.RabbitMQ.MongoDB/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+services:
+  
+  mongodb:
+    hostname: cap-mongodb
+    container_name: cap-mongodb
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_DATABASE: test
+      MONGO_REPLICA_SET_NAME: rs0
+    volumes:
+      - ./mongo-initdb.d:/docker-entrypoint-initdb.d
+    expose:
+      - 27017
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: test $$(echo "rs.initiate().ok || rs.slaveOk().ok || rs.status().ok" | mongo --quiet) -eq 1
+      interval: 10s
+      start_period: 30s
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    networks:
+      - cap-net
+  
+  rabbitmq:
+    image: rabbitmq:latest
+    container_name: cap-rabbitmq
+    ports:
+      - 5672:5672
+      - 15672:15672
+    volumes:
+      - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
+      - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
+    networks:
+      - cap-net
+
+networks:
+  cap-net:
+    name: cap-net
+    driver: bridge
+  

--- a/src/DotNetCore.CAP.MongoDB/IMonitoringApi.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IMonitoringApi.MongoDB.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
 using DotNetCore.CAP.Persistence;
 using Microsoft.Extensions.Options;
-using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace DotNetCore.CAP.MongoDB
@@ -85,44 +85,82 @@ namespace DotNetCore.CAP.MongoDB
 
         public PagedQueryResult<MessageDto> Messages(MessageQueryDto queryDto)
         {
-            var name = queryDto.MessageType == MessageType.Publish
-                ? _options.PublishedCollection
-                : _options.ReceivedCollection;
-            var collection = _database.GetCollection<BsonDocument>(name);
+            return queryDto.MessageType == MessageType.Publish
+                       ? FindPublishedMessages(queryDto)
+                       : FindReceivedMessages(queryDto);
+        }
 
-            var builder = Builders<BsonDocument>.Filter;
+        private PagedQueryResult<MessageDto> FindReceivedMessages(MessageQueryDto queryDto)
+        {
+            var collection = _database.GetCollection<ReceivedMessage>(_options.ReceivedCollection);
+            var builder = Builders<ReceivedMessage>.Filter;
             var filter = builder.Empty;
             if (!string.IsNullOrEmpty(queryDto.StatusName))
-                filter &= builder.Regex("StatusName", $"/{queryDto.StatusName}/i");
+                filter &= builder.Regex(x => x.StatusName, $"/{queryDto.StatusName}/i");
 
-            if (!string.IsNullOrEmpty(queryDto.Name)) filter &= builder.Eq("Name", queryDto.Name);
+            if (!string.IsNullOrEmpty(queryDto.Name)) filter &= builder.Eq(x => x.Name, queryDto.Name);
 
-            if (!string.IsNullOrEmpty(queryDto.Group)) filter &= builder.Eq("Group", queryDto.Group);
+            if (!string.IsNullOrEmpty(queryDto.Group)) filter &= builder.Eq(x => x.Group, queryDto.Group);
 
             if (!string.IsNullOrEmpty(queryDto.Content))
-                filter &= builder.Regex("Content", $".*{queryDto.Content}.*");
+                filter &= builder.Regex(x => x.Content, $".*{queryDto.Content}.*");
 
-            ProjectionDefinition<BsonDocument, MessageDto> projection =
-                new FindExpressionProjectionDefinition<BsonDocument, MessageDto>(p => new MessageDto
-                {
-                    Id = p["_id"].ToString(),
-                    Version = p["Version"].ToString(),
-                    Group = p["Group"] == null ? null : p["Group"].ToString(),
-                    Name = p["Name"].ToString(),
-                    Content = p["Content"].ToString(),
-                    Added = p["Added"].ToLocalTime(),
-                    ExpiresAt = p["ExpiresAt"].ToNullableLocalTime(),
-                    Retries = p["Retries"].ToInt32(),
-                    StatusName = p["StatusName"].ToString()
-                });
+            var items = collection.Find(filter)
+                                  .SortByDescending(x => x.Added)
+                                  .Skip(queryDto.PageSize * queryDto.CurrentPage)
+                                  .Limit(queryDto.PageSize)
+                                  .ToList()
+                                  .Select(x => new MessageDto
+                                               {
+                                                   Id = x.Id.ToString(),
+                                                   Version = x.Version.ToString(),
+                                                   Group = x.Group,
+                                                   Name = x.Name,
+                                                   Content = x.Content,
+                                                   Added = x.Added.ToLocalTime(),
+                                                   ExpiresAt = x.ExpiresAt?.ToLocalTime(),
+                                                   Retries = x.Retries,
+                                                   StatusName = x.StatusName
+                                               })
+                                  .ToList();
 
-            var items = collection
-                .Find(filter)
-                .SortByDescending(x => x["Added"])
-                .Skip(queryDto.PageSize * queryDto.CurrentPage)
-                .Limit(queryDto.PageSize)
-                .Project(projection)
-                .ToList();
+            var count = collection.CountDocuments(filter);
+
+            return new PagedQueryResult<MessageDto> { Items = items, PageIndex = queryDto.CurrentPage, PageSize = queryDto.PageSize, Totals = count };
+        }
+
+        private PagedQueryResult<MessageDto> FindPublishedMessages(MessageQueryDto queryDto)
+        {
+            var collection = _database.GetCollection<PublishedMessage>(_options.PublishedCollection);
+
+            var builder = Builders<PublishedMessage>.Filter;
+            var filter = builder.Empty;
+            if (!string.IsNullOrEmpty(queryDto.StatusName))
+                filter &= builder.Regex(x => x.StatusName, $"/{queryDto.StatusName}/i");
+
+            if (!string.IsNullOrEmpty(queryDto.Name)) filter &= builder.Eq(x => x.Name, queryDto.Name);
+
+            if (!string.IsNullOrEmpty(queryDto.Content))
+                filter &= builder.Regex(x => x.Content, $".*{queryDto.Content}.*");
+
+            var items = collection.Find(filter)
+                                  .SortByDescending(x => x.Added)
+                                  .Skip(queryDto.PageSize * queryDto.CurrentPage)
+                                  .Limit(queryDto.PageSize)
+                                  .ToList()
+                                  .Select(x => new MessageDto
+                                               {
+                                                   Id = x.Id.ToString(),
+                                                   Version = x.Version.ToString(),
+                                                   Group = null,
+                                                   Name = x.Name,
+                                                   Content = x.Content,
+                                                   Added = x.Added.ToLocalTime(),
+                                                   ExpiresAt = x.ExpiresAt?.ToLocalTime(),
+                                                   Retries = x.Retries,
+                                                   StatusName = x.StatusName
+                                               })
+                                  .ToList();
 
             var count = collection.CountDocuments(filter);
 
@@ -151,70 +189,54 @@ namespace DotNetCore.CAP.MongoDB
 
         private int GetNumberOfMessage(string collectionName, string statusName)
         {
-            var collection = _database.GetCollection<BsonDocument>(collectionName);
-            var count = collection.CountDocuments(new BsonDocument { { "StatusName", statusName } });
+            return collectionName.Equals(_options.PublishedCollection, StringComparison.InvariantCultureIgnoreCase)
+                       ? GetNumberOfPublishedMessages(statusName)
+                       : GetNumberOfReceivedMessages(statusName);
+        }
+
+        private int GetNumberOfReceivedMessages(string statusName)
+        {
+            var collection = _database.GetCollection<ReceivedMessage>(_options.ReceivedCollection);
+            var filter = Builders<ReceivedMessage>.Filter.Eq(x => x.StatusName, statusName);
+            var count = collection.CountDocuments(filter);
+            return int.Parse(count.ToString());
+        }
+
+        private int GetNumberOfPublishedMessages(string statusName)
+        {
+            var collection = _database.GetCollection<PublishedMessage>(_options.PublishedCollection);
+            var filter = Builders<PublishedMessage>.Filter.Eq(x => x.StatusName, statusName);
+            var count = collection.CountDocuments(filter);
             return int.Parse(count.ToString());
         }
 
         private IDictionary<DateTime, int> GetHourlyTimelineStats(MessageType type, string statusName)
         {
-            var collectionName =
-                type == MessageType.Publish ? _options.PublishedCollection : _options.ReceivedCollection;
             var endDate = DateTime.UtcNow;
+            var published = _database.GetCollection<PublishedMessage>(_options.PublishedCollection).AsQueryable();
+            var received = _database.GetCollection<PublishedMessage>(_options.PublishedCollection).AsQueryable();
 
-            var groupby = new BsonDocument
-            {
-                {
-                    "$group", new BsonDocument
-                    {
-                        {
-                            "_id", new BsonDocument
-                            {
-                                {
-                                    "Key", new BsonDocument
-                                    {
-                                        {
-                                            "$dateToString", new BsonDocument
-                                            {
-                                                {"format", "%Y-%m-%d %H:00:00"},
-                                                {"date", "$Added"}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {"Count", new BsonDocument {{"$sum", 1}}}
-                    }
-                }
-            };
-
-            var match = new BsonDocument
-            {
-                {
-                    "$match", new BsonDocument
-                    {
-                        {
-                            "Added", new BsonDocument
-                            {
-                                {"$gt", endDate.AddHours(-24)}
-                            }
-                        },
-                        {
-                            "StatusName",
-                            new BsonDocument
-                            {
-                                {"$eq", statusName}
-                            }
-                        }
-                    }
-                }
-            };
-
-            var pipeline = new[] { match, groupby };
-
-            var collection = _database.GetCollection<BsonDocument>(collectionName);
-            var result = collection.Aggregate<BsonDocument>(pipeline).ToList();
+            var result = type == MessageType.Publish 
+                             ? published.Where(x => x.Added > endDate.AddHours(-24) && x.StatusName == statusName)
+                                        .GroupBy(x => new
+                                                      {
+                                                          x.Added.Year,
+                                                          x.Added.Month,
+                                                          x.Added.Day,
+                                                          x.Added.Hour
+                                                      })
+                                        .Select(kv => new { kv.Key, Count = kv.Count() })
+                                        .ToList()
+                             : received.Where(x => x.Added > endDate.AddHours(-24) && x.StatusName == statusName)
+                                       .GroupBy(x => new
+                                                     {
+                                                         x.Added.Year,
+                                                         x.Added.Month,
+                                                         x.Added.Day,
+                                                         x.Added.Hour
+                                                     })
+                                       .Select(kv => new { kv.Key, Count = kv.Count() })
+                                       .ToList();
 
             var dic = new Dictionary<DateTime, int>();
             for (var i = 0; i < 24; i++)
@@ -225,8 +247,8 @@ namespace DotNetCore.CAP.MongoDB
 
             result.ForEach(d =>
             {
-                var key = d["_id"].AsBsonDocument["Key"].AsString;
-                if (DateTime.TryParse(key, out var dateTime)) dic[dateTime.ToLocalTime()] = d["Count"].AsInt32;
+                var dateTime = new DateTime(d.Key.Year, d.Key.Month, d.Key.Day, d.Key.Hour, 0, 0);
+                dic[dateTime.ToLocalTime()] = d.Count;
             });
 
             return dic;


### PR DESCRIPTION
When CAP is using MongoDB with a different element name convention registered in the convention registry, the queries does not work as expected.

This occurs because some queries are mapping properties as strings, and once a different case convention is registered (CamelCaseElementNameConvention, as example), they don't behave as expected.

In order to resolve this issue, I changed the queries to use LINQ instead of Bson Documents. I didn't try to abstract PublishedMessage and ReceivedMessage and simply encapsulate the necessary logic to behave accordingly in each case based on the message type.