### PR TITLE
Support .NET Framework and .NET Standard 2.0

### DIFF
--- a/CAP.sln
+++ b/CAP.sln
@@ -86,7 +86,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.RabbitMQ.SqlServer.D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.OpenTelemetry", "src\DotNetCore.CAP.OpenTelemetry\DotNetCore.CAP.OpenTelemetry.csproj", "{83DDB126-A00B-4064-86E7-568322CA67EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.AzureServiceBus.InMemory", "samples\Sample.AzureServiceBus.InMemory\Sample.AzureServiceBus.InMemory.csproj", "{0C734FB2-7D75-4FF3-B564-1E50E6280B14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.AzureServiceBus.InMemory", "samples\Sample.AzureServiceBus.InMemory\Sample.AzureServiceBus.InMemory.csproj", "{0C734FB2-7D75-4FF3-B564-1E50E6280B14}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.NetFramework.Postgres", "samples\Sample.NetFramework.Postgres\Sample.NetFramework.Postgres.csproj", "{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -214,6 +216,10 @@ Global
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +255,7 @@ Global
 		{DCDF58E8-F823-4F04-9F8C-E8076DC16A68} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 		{83DDB126-A00B-4064-86E7-568322CA67EC} = {9B2AE124-6636-4DE9-83A3-70360DABD0C4}
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14} = {3A6B6931-A123-477A-9469-8B468B5385AF}
+		{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E70565D-94CF-40B4-BFE1-AC18D5F736AB}

--- a/build/BuildScript.csproj
+++ b/build/BuildScript.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Sample.NetFramework.Postgres/App_Start/RouteConfig.cs
+++ b/samples/Sample.NetFramework.Postgres/App_Start/RouteConfig.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace Sample.NetFramework.Postgres
+{
+    public class RouteConfig
+    {
+        public static void RegisterRoutes(RouteCollection routes)
+        {
+            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+            routes.MapRoute(
+                name: "Default",
+                url: "{controller}/{action}/{id}",
+                defaults: new { controller = "Home", action = "Publish", id = UrlParameter.Optional }
+            );
+
+            routes.MapRoute(
+                name: "DefaultNoArgs",
+                url: "",
+                defaults: new { controller = "Home", action = "Publish" }
+            );
+        }
+    }
+}

--- a/samples/Sample.NetFramework.Postgres/Controllers/HomeController.cs
+++ b/samples/Sample.NetFramework.Postgres/Controllers/HomeController.cs
@@ -1,0 +1,30 @@
+﻿using DotNetCore.CAP;
+using System;
+using System.Web.Mvc;
+
+namespace Sample.NetFramework.Postgres.Controllers
+{
+    public class HomeController : Controller
+    {
+        private ICapPublisher _capPublisher;
+
+        public HomeController(ICapPublisher capPublisher)
+        {
+            _capPublisher = capPublisher;
+        }
+
+        // GET: Home
+        public ActionResult Publish()
+        {
+            _capPublisher.PublishAsync("SampleTopic", DateTime.Now);
+            Console.WriteLine("Published to SampleTopic");
+            return null;
+        }
+
+        [CapSubscribe("SampleTopic")]
+        public void Subscribe(Object obj)
+        {
+            Console.WriteLine($"Received {obj} from SampleTopic queue");
+        }
+    }
+}

--- a/samples/Sample.NetFramework.Postgres/DefaultDependencyResolver.cs
+++ b/samples/Sample.NetFramework.Postgres/DefaultDependencyResolver.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Web.Mvc;
+
+namespace Sample.NetFramework.Postgres
+{
+    public class DefaultDependencyResolver : IDependencyResolver
+    {
+        protected IServiceProvider serviceProvider;
+
+        public DefaultDependencyResolver(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return this.serviceProvider.GetService(serviceType);
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            return this.serviceProvider.GetServices(serviceType);
+        }
+    }
+}

--- a/samples/Sample.NetFramework.Postgres/Global.asax
+++ b/samples/Sample.NetFramework.Postgres/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="Sample.NetFramework.Postgres.MvcApplication" Language="C#" %>

--- a/samples/Sample.NetFramework.Postgres/Global.asax.cs
+++ b/samples/Sample.NetFramework.Postgres/Global.asax.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace Sample.NetFramework.Postgres
+{
+    public class MvcApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            RouteConfig.RegisterRoutes(RouteTable.Routes);
+        }
+
+        protected void Application_End(object sender, EventArgs e)
+        {
+            // clean up CAP bootstrapper (created in Startup.StartCAP method)
+            if (Application["CAPBootstrapper"] != null)
+            {
+                Application.Lock();
+                var bootstrapper = Application["CAPBootstrapper"] as DotNetCore.CAP.Internal.Bootstrapper;
+
+                if (bootstrapper != null)
+                {
+                    Task.Run(async () => { await bootstrapper.StopAsync(CancellationToken.None); }).Wait();
+                    bootstrapper.Dispose();
+                }
+
+                Application["CAPBootstrapper"] = null;
+                Application.UnLock();
+            }
+        }
+    }
+}

--- a/samples/Sample.NetFramework.Postgres/Sample.NetFramework.Postgres.csproj
+++ b/samples/Sample.NetFramework.Postgres/Sample.NetFramework.Postgres.csproj
@@ -1,0 +1,287 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A5D685F-4D7D-49DB-8BA4-5313C10F2A42}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sample.NetFramework.Postgres</RootNamespace>
+    <AssemblyName>Sample.NetFramework.Postgres</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Core.3.7.3.33\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.SimpleNotificationService, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.SimpleNotificationService.3.7.2.64\lib\net45\AWSSDK.SimpleNotificationService.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.SQS, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.SQS.3.7.1.36\lib\net45\AWSSDK.SQS.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.EntityFrameworkCore, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.EntityFrameworkCore.2.2.0\lib\netstandard2.0\Microsoft.EntityFrameworkCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.EntityFrameworkCore.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.EntityFrameworkCore.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.EntityFrameworkCore.Relational, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.EntityFrameworkCore.Relational.2.2.0\lib\netstandard2.0\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Memory.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Caching.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Hosting.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.4.2.2\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Npgsql, Version=4.1.6.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Npgsql.4.1.6\lib\net461\Npgsql.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.5.0.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Interactive.Async.3.2.0\lib\net46\System.Interactive.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Json.6.0.0\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Channels, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Channels.6.0.0\lib\net461\System.Threading.Channels.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Web.Razor">
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Webpages">
+      <HintPath>..\..\packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Webpages.Deployment">
+      <HintPath>..\..\packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Webpages.Razor">
+      <HintPath>..\..\packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Helpers">
+      <HintPath>..\..\packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure">
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc">
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="DefaultDependencyResolver.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetCore.CAP.AmazonSQS\DotNetCore.CAP.AmazonSQS.csproj">
+      <Project>{43475e00-51b7-443d-bc2d-fc21f9d8a0b4}</Project>
+      <Name>DotNetCore.CAP.AmazonSQS</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetCore.CAP.PostgreSql\DotNetCore.CAP.PostgreSql.csproj">
+      <Project>{82c403ab-ed68-4084-9a1d-11334f9f08f9}</Project>
+      <Name>DotNetCore.CAP.PostgreSql</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetCore.CAP\DotNetCore.CAP.csproj">
+      <Project>{e8af8611-0ea4-4b19-bc48-87c57a87dc66}</Project>
+      <Name>DotNetCore.CAP</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\AWSSDK.SimpleNotificationService.3.7.2.64\analyzers\dotnet\cs\AWSSDK.SimpleNotificationService.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.SQS.3.7.1.36\analyzers\dotnet\cs\AWSSDK.SQS.CodeAnalysis.dll" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>51545</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:51545/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('..\..\packages\System.Text.Json.6.0.0\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Text.Json.6.0.0\build\System.Text.Json.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\System.Text.Json.6.0.0\build\System.Text.Json.targets" Condition="Exists('..\..\packages\System.Text.Json.6.0.0\build\System.Text.Json.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/Sample.NetFramework.Postgres/Startup.cs
+++ b/samples/Sample.NetFramework.Postgres/Startup.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Web.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Owin;
+using Owin;
+
+[assembly: OwinStartup(typeof(Sample.NetFramework.Postgres.Startup))]
+
+namespace Sample.NetFramework.Postgres
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            // configure CAP
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            ConfigureServices(services);
+            var dependencyResolver = ConfigureDI(services);
+            StartCAP(dependencyResolver);
+        }
+
+        private void ConfigureServices(ServiceCollection services)
+        {
+            services.AddCap(x =>
+            {
+                x.TopicNamePrefix = "Sample";
+                x.GroupNamePrefix = "Sample";
+                x.UseAmazonSQS(options =>
+                {
+                    options.Region = Amazon.RegionEndpoint.APSoutheast2;
+                });
+                x.UsePostgreSql(options =>
+                {
+                    options.ConnectionString = "<INSERT HERE>";
+                    options.Schema = "Sample";
+                });
+                x.ConsumingAssembly = Assembly.GetExecutingAssembly();      // this has to be the assembly where your [CAPSubscribe] methods are defined
+                                                                            //          - if you don't set this, CAP won't find and register those methods as listeners
+            });
+
+            // note, if you're using a logger other than Microsoft.Extensions.Logging.ILogger, you still need this
+            // or else CAP will fall over when it tries to log
+            services.AddLogging();
+
+            // register controllers
+            var controllerTypes = Assembly.GetExecutingAssembly().GetExportedTypes()
+                .Where(t => !t.IsAbstract && !t.IsGenericTypeDefinition)
+                .Where(t => typeof(IController).IsAssignableFrom(t) || t.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var controllerType in controllerTypes)
+                services.AddTransient(controllerType);
+        }
+
+        private IDependencyResolver ConfigureDI(ServiceCollection serviceCollection)
+        {
+            // note, if you're using DI other than Microsoft.Extensions, just populate serviceCollection into that (to get all the CAP DI registrations) instead of doing this
+
+            // this is how to do it for an MVC project - would be different for a WebAPI or Console App project
+            var dependencyResolver = new DefaultDependencyResolver(serviceCollection.BuildServiceProvider());
+            DependencyResolver.SetResolver(dependencyResolver);
+            return dependencyResolver;
+        }
+
+        private void StartCAP(IDependencyResolver dependencyResolver)
+        {
+            // and start CAP running (normally, this is done automatically by CAP as a IHost background job,
+            // but .NET Framework doesn't run the infrastructure for this, so you need to do it manually)
+
+            // (or do this using Hangfire.IO, etc, but note it MUST be running from the same DI container since the Bootstrapper instance MUST be a singleton)
+            var capBootstrapper = dependencyResolver.GetService<DotNetCore.CAP.Internal.Bootstrapper>();
+            capBootstrapper.StartIfNotAlreadyRunning();
+
+            // store the bootstrapper in state so we can dispose of it properly in Global.asax on application shutdown
+            var state = System.Web.HttpContext.Current?.Application;
+            if (state != null)
+            {
+                state.Lock();
+                state["CAPBootstrapper"] = capBootstrapper;
+                state.UnLock();
+            }
+        }
+    }
+}

--- a/samples/Sample.NetFramework.Postgres/Web.Debug.config
+++ b/samples/Sample.NetFramework.Postgres/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Sample.NetFramework.Postgres/Web.Release.config
+++ b/samples/Sample.NetFramework.Postgres/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/samples/Sample.NetFramework.Postgres/Web.config
+++ b/samples/Sample.NetFramework.Postgres/Web.config
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=301880
+  -->
+<configuration>
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7.2" />
+    <httpRuntime targetFramework="4.7.2" />
+  </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/samples/Sample.NetFramework.Postgres/packages.config
+++ b/samples/Sample.NetFramework.Postgres/packages.config
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AWSSDK.Core" version="3.7.3.33" targetFramework="net472" />
+  <package id="AWSSDK.SimpleNotificationService" version="3.7.2.64" targetFramework="net472" />
+  <package id="AWSSDK.SQS" version="3.7.1.36" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net472" />
+  <package id="Microsoft.EntityFrameworkCore" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.EntityFrameworkCore.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.EntityFrameworkCore.Analyzers" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.EntityFrameworkCore.Relational" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net472" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Npgsql" version="4.1.6" targetFramework="net472" />
+  <package id="Owin" version="1.0" targetFramework="net472" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="5.0.1" targetFramework="net472" />
+  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="6.0.0" targetFramework="net472" />
+  <package id="System.Threading.Channels" version="6.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+</packages>

--- a/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonPolicyExtensions.cs
@@ -191,7 +191,7 @@ namespace DotNetCore.CAP.AmazonSQS
                 foreach (var topicArn in statement.Conditions.SelectMany(c => c.Values))
                 {
                     topicArns.Add(
-                        groupName != null && topicArn.Contains(groupName, StringComparison.InvariantCultureIgnoreCase)
+                        groupName != null && topicArn.ContainsIgnoreCase(groupName)
                             ? $"{GetArnGroupPrefix(topicArn)}-*"
                             : topicArn);
                 }
@@ -223,7 +223,7 @@ namespace DotNetCore.CAP.AmazonSQS
                 return null;
             }
 
-            return string.Join(separator, groupPaths.Take(groupPaths.Length - 1));
+            return string.Join(new string(separator,1), groupPaths.Take(groupPaths.Length - 1));
         }
         
         /// <summary>
@@ -250,6 +250,25 @@ namespace DotNetCore.CAP.AmazonSQS
             }
 
             return GetArnGroupPrefix(name);
+        }
+
+        /// <summary>
+        /// Return whether stringToSearch contains substringToFind, regardless of case (framework-independent)
+        /// </summary>
+        /// <param name="stringToSearch"></param>
+        /// <param name="substringToFind"></param>
+        /// <returns></returns>
+        private static bool ContainsIgnoreCase(this string stringToSearch, string substringToFind)
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            return stringToSearch.Contains(substringToFind, StringComparison.InvariantCultureIgnoreCase);
+#elif NET
+            return stringToSearch.Contains(substringToFind, StringComparison.InvariantCultureIgnoreCase);
+#else
+            stringToSearch = stringToSearch.ToUpperInvariant();
+            substringToFind = substringToFind.ToUpperInvariant();
+            return stringToSearch.Contains(substringToFind);
+#endif
         }
     }
 }

--- a/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
@@ -98,7 +98,7 @@ namespace DotNetCore.CAP.AmazonSQS
                 {
                     var messageObj = JsonSerializer.Deserialize<SQSReceivedMessage>(response.Messages[0].Body);
 
-                    var header = messageObj!.MessageAttributes.ToDictionary(x => x.Key, x => x.Value.Value);
+                    var header = messageObj!.MessageAttributes?.ToDictionary(x => x.Key, x => x.Value.Value) ?? new Dictionary<string, string?>();
                     var body = messageObj.Message;
 
                     var message = new TransportMessage(header, body != null ? Encoding.UTF8.GetBytes(body) : null);

--- a/src/DotNetCore.CAP.AmazonSQS/DotNetCore.CAP.AmazonSQS.csproj
+++ b/src/DotNetCore.CAP.AmazonSQS/DotNetCore.CAP.AmazonSQS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);AmazonSQS;SQS</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/ITransport.AmazonSQS.cs
@@ -143,7 +143,7 @@ namespace DotNetCore.CAP.AmazonSQS
             }
         }
         
-        private bool TryGetOrCreateTopicArn(string topicName,[System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? topicArn)
+        private bool TryGetOrCreateTopicArn(string topicName,out string? topicArn)
         {
             topicArn = null;
             if (_topicArnMaps!.TryGetValue(topicName, out topicArn))

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -42,6 +42,11 @@ namespace DotNetCore.CAP.AzureServiceBus
 
         public BrokerAddress BrokerAddress => new ("AzureServiceBus", _asbOptions.ConnectionString);
 
+        public ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
+
         public void Subscribe(IEnumerable<string> topics)
         {
             if (topics == null)
@@ -196,9 +201,10 @@ namespace DotNetCore.CAP.AzureServiceBus
             {
                 foreach (var customHeader in customHeaders)
                 {
-                    var added = headers.TryAdd(customHeader.Key, customHeader.Value);
-
-                    if (!added)
+                    try
+                    {
+                        headers.Add(customHeader.Key, customHeader.Value);
+                    } catch
                     {
                         _logger.LogWarning(
                             "Not possible to add the custom header {Header}. A value with the same key already exists in the Message headers.", 

--- a/src/DotNetCore.CAP.AzureServiceBus/DotNetCore.CAP.AzureServiceBus.csproj
+++ b/src/DotNetCore.CAP.AzureServiceBus/DotNetCore.CAP.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);AzureServiceBus</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.InMemoryStorage/DotNetCore.CAP.InMemoryStorage.csproj
+++ b/src/DotNetCore.CAP.InMemoryStorage/DotNetCore.CAP.InMemoryStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);InMemory</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.Kafka/DotNetCore.CAP.Kafka.csproj
+++ b/src/DotNetCore.CAP.Kafka/DotNetCore.CAP.Kafka.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);Kafka</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.MongoDB/DotNetCore.CAP.MongoDB.csproj
+++ b/src/DotNetCore.CAP.MongoDB/DotNetCore.CAP.MongoDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);MongoDB</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.MySql/DotNetCore.CAP.MySql.csproj
+++ b/src/DotNetCore.CAP.MySql/DotNetCore.CAP.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net472</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageTags>$(PackageTags);MySQL</PackageTags>
 	</PropertyGroup>
@@ -14,6 +14,11 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
+		<PackageReference Include="MySqlConnector" Version="2.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.21" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.21" />
 		<PackageReference Include="MySqlConnector" Version="2.0.0" />
 	</ItemGroup>
 	

--- a/src/DotNetCore.CAP.NATS/DotNetCore.CAP.NATS.csproj
+++ b/src/DotNetCore.CAP.NATS/DotNetCore.CAP.NATS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);NATS</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.OpenTelemetry/DotNetCore.CAP.OpenTelemetry.csproj
+++ b/src/DotNetCore.CAP.OpenTelemetry/DotNetCore.CAP.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
 	<Description>CAP instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;opentelemetry;</PackageTags>

--- a/src/DotNetCore.CAP.PostgreSql/DotNetCore.CAP.PostgreSql.csproj
+++ b/src/DotNetCore.CAP.PostgreSql/DotNetCore.CAP.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net472</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageTags>$(PackageTags);PostgreSQL</PackageTags>
 	</PropertyGroup>
@@ -16,6 +16,12 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
 		<PackageReference Include="Npgsql" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
+		<PackageReference Include="Npgsql" Version="4.1.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DotNetCore.CAP.PostgreSql/ICapTransaction.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/ICapTransaction.PostgreSql.cs
@@ -37,6 +37,7 @@ namespace DotNetCore.CAP
             Flush();
         }
 
+#pragma warning disable CS1988  // this method is async only if >= NETSTANDARD2.1 (since that's when EF started supporting it) - suppress 'not async' warning for the older frameworks
         public override async Task CommitAsync(CancellationToken cancellationToken = default)
         {
             Debug.Assert(DbTransaction != null);
@@ -47,12 +48,17 @@ namespace DotNetCore.CAP
                     dbTransaction.Commit();
                     break;
                 case IDbContextTransaction dbContextTransaction:
+#if NETSTANDARD2_0 || NETFRAMEWORK
+                    dbContextTransaction.Commit();
+#else
                     await dbContextTransaction.CommitAsync(cancellationToken);
+#endif
                     break;
             }
 
             Flush();
         }
+#pragma warning restore CS1988
 
         public override void Rollback()
         {
@@ -69,6 +75,7 @@ namespace DotNetCore.CAP
             }
         }
 
+#pragma warning disable CS1988  // this method is async only if >= NETSTANDARD2.1 (since that's when EF started supporting it) - suppress 'not async' warning for the older frameworks
         public override async Task RollbackAsync(CancellationToken cancellationToken = default)
         {
             Debug.Assert(DbTransaction != null);
@@ -79,10 +86,15 @@ namespace DotNetCore.CAP
                     dbTransaction.Rollback();
                     break;
                 case IDbContextTransaction dbContextTransaction:
+#if NETSTANDARD2_0 || NETFRAMEWORK
+                    dbContextTransaction.Rollback();
+#else
                     await dbContextTransaction.RollbackAsync(cancellationToken);
+#endif
                     break;
             }
         }
+#pragma warning restore CS1988
 
         public override void Dispose()
         {

--- a/src/DotNetCore.CAP.Pulsar/DotNetCore.CAP.Pulsar.csproj
+++ b/src/DotNetCore.CAP.Pulsar/DotNetCore.CAP.Pulsar.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);Pulsar</PackageTags>
 	<NoWarn>CS0067</NoWarn>

--- a/src/DotNetCore.CAP.Pulsar/PulsarConsumerClient.cs
+++ b/src/DotNetCore.CAP.Pulsar/PulsarConsumerClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using DotNetCore.CAP.Messages;
@@ -32,6 +33,11 @@ namespace DotNetCore.CAP.Pulsar
         public event EventHandler<LogMessageEventArgs>? OnLog;
 
         public BrokerAddress BrokerAddress => new ("Pulsar", _pulsarOptions.ServiceUrl);
+
+        public ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
 
         public void Subscribe(IEnumerable<string> topics)
         {

--- a/src/DotNetCore.CAP.RabbitMQ/DotNetCore.CAP.RabbitMQ.csproj
+++ b/src/DotNetCore.CAP.RabbitMQ/DotNetCore.CAP.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 	<Nullable>enable</Nullable>
     <PackageTags>$(PackageTags);RabbitMQ</PackageTags>
   </PropertyGroup>

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using DotNetCore.CAP.Messages;
@@ -40,6 +41,10 @@ namespace DotNetCore.CAP.RabbitMQ
 
         public BrokerAddress BrokerAddress => new("RabbitMQ", $"{_rabbitMQOptions.HostName}:{_rabbitMQOptions.Port}");
 
+        public ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
         public void Subscribe(IEnumerable<string> topics)
         {
             if (topics == null)

--- a/src/DotNetCore.CAP.RedisStreams/DotNetCore.CAP.RedisStreams.csproj
+++ b/src/DotNetCore.CAP.RedisStreams/DotNetCore.CAP.RedisStreams.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageTags>$(PackageTags);RedisStreams</PackageTags>
 	</PropertyGroup>

--- a/src/DotNetCore.CAP.RedisStreams/IConsumerClient.Redis.cs
+++ b/src/DotNetCore.CAP.RedisStreams/IConsumerClient.Redis.cs
@@ -40,6 +40,11 @@ namespace DotNetCore.CAP.RedisStreams
 
         public BrokerAddress BrokerAddress => new("redis", _options.Value.Endpoint);
 
+        public ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
+
         public void Subscribe(IEnumerable<string> topics)
         {
             if (topics == null) throw new ArgumentNullException(nameof(topics));

--- a/src/DotNetCore.CAP.RedisStreams/TransportMessage.Redis.cs
+++ b/src/DotNetCore.CAP.RedisStreams/TransportMessage.Redis.cs
@@ -37,7 +37,7 @@ namespace DotNetCore.CAP.RedisStreams
 
             var body = !bodyRaw.IsNullOrEmpty ? JsonSerializer.Deserialize<byte[]>(bodyRaw) : null;
 
-            headers.TryAdd(Messages.Headers.Group, groupId);
+            try { headers.Add(Messages.Headers.Group, groupId); } catch { }
 
             return new TransportMessage(headers, body);
         }

--- a/src/DotNetCore.CAP.SqlServer/Diagnostics/DiagnosticObserver.cs
+++ b/src/DotNetCore.CAP.SqlServer/Diagnostics/DiagnosticObserver.cs
@@ -43,8 +43,10 @@ namespace DotNetCore.CAP.SqlServer.Diagnostics
             {
                 case SqlAfterCommitTransactionMicrosoft:
                 {
+#nullable disable warnings
                     if (!TryGetSqlConnection(evt, out SqlConnection? sqlConnection)) return;
                     var transactionKey = sqlConnection.ClientConnectionId;
+#nullable enable warnings
                     if (_bufferList.TryRemove(transactionKey, out var msgList))
                     {
                         foreach (var message in msgList)
@@ -59,9 +61,10 @@ namespace DotNetCore.CAP.SqlServer.Diagnostics
                 {
                     if (!_bufferList.IsEmpty)
                     {
+#nullable disable warnings
                         if (!TryGetSqlConnection(evt, out SqlConnection? sqlConnection)) return;
                         var transactionKey = sqlConnection.ClientConnectionId;
-
+#nullable enable warnings
                         _bufferList.TryRemove(transactionKey, out _);
                     }
 
@@ -70,7 +73,7 @@ namespace DotNetCore.CAP.SqlServer.Diagnostics
             }
         }
 
-        private static bool TryGetSqlConnection(KeyValuePair<string, object?> evt, [NotNullWhen(true)] out SqlConnection? sqlConnection)
+        private static bool TryGetSqlConnection(KeyValuePair<string, object?> evt, out SqlConnection? sqlConnection)
         {
             sqlConnection = GetProperty(evt.Value, "Connection") as SqlConnection;
             return sqlConnection != null;

--- a/src/DotNetCore.CAP.SqlServer/DotNetCore.CAP.SqlServer.csproj
+++ b/src/DotNetCore.CAP.SqlServer/DotNetCore.CAP.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net472</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageTags>$(PackageTags);SQL Server</PackageTags>
 	</PropertyGroup>
@@ -16,6 +16,12 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.21" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.21" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DotNetCore.CAP.SqlServer/IMonitoringApi.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IMonitoringApi.SqlServer.cs
@@ -254,11 +254,15 @@ select [Key], [Count] from aggr with (nolock) where [Key] >= @minKey and [Key] <
             return result;
         }
 
+#pragma warning disable CS1998
         private async Task<MediumMessage?> GetMessageAsync(string tableName, long id)
         {
             var sql = $@"SELECT TOP 1 Id AS DbId, Content, Added, ExpiresAt, Retries FROM {tableName} WITH (readpast) WHERE Id={id}";
-
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            using var connection = new SqlConnection(_options.ConnectionString);
+#else
             await using var connection = new SqlConnection(_options.ConnectionString);
+#endif
             var mediumMessage = connection.ExecuteReader(sql, reader =>
             {
                 MediumMessage? message = null;
@@ -280,5 +284,6 @@ select [Key], [Count] from aggr with (nolock) where [Key] >= @minKey and [Key] <
 
             return mediumMessage;
         }
+#pragma warning restore CS1998
     }
 }

--- a/src/DotNetCore.CAP.SqlServer/IStorageInitializer.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorageInitializer.SqlServer.cs
@@ -33,16 +33,22 @@ namespace DotNetCore.CAP.SqlServer
             return $"{_options.Value.Schema}.Received";
         }
 
+#pragma warning disable CS1998
         public async Task InitializeAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested) return;
 
             var sql = CreateDbTablesScript(_options.Value.Schema);
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            using (var connection = new SqlConnection(_options.Value.ConnectionString))
+#else
             await using (var connection = new SqlConnection(_options.Value.ConnectionString))
+#endif
                 connection.ExecuteNonQuery(sql);
 
             _logger.LogDebug("Ensuring all create database tables script are applied.");
         }
+#pragma warning restore CS1998
 
         protected virtual string CreateDbTablesScript(string schema)
         {

--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -26,9 +26,10 @@ namespace DotNetCore.CAP
             ProducerThreadCount = 1;
             Extensions = new List<ICapOptionsExtension>();
             Version = "v1";
-            DefaultGroupName = "cap.queue." + Assembly.GetEntryAssembly()?.GetName().Name.ToLower();
+            DefaultGroupName = "cap.queue." + (Assembly.GetEntryAssembly()?.GetName().Name.ToLower() ?? ConsumingAssembly?.GetName().Name.ToLower());
             CollectorCleaningInterval = 300;
             UseDispatchingPerGroup = false;
+            ConsumingAssembly = Assembly.GetEntryAssembly();
         }
 
         internal IList<ICapOptionsExtension> Extensions { get; }
@@ -124,5 +125,11 @@ namespace DotNetCore.CAP
         /// Configure JSON serialization settings
         /// </summary>
         public JsonSerializerOptions JsonSerializerOptions { get; } = new ();
+
+        /// <summary>
+        /// Define the assembly that is calling this (and so will be searched for CAPSubscribers and CAP publishing)
+        /// Defaults to Assembly.EntryAssembly() if not set
+        /// </summary>
+        public Assembly ConsumingAssembly { get; set; }
     }
 }

--- a/src/DotNetCore.CAP/DotNetCore.CAP.csproj
+++ b/src/DotNetCore.CAP/DotNetCore.CAP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
   
@@ -9,14 +9,24 @@
     <DocumentationFile>bin\$(Configuration)\netstandard2.1\DotNetCore.CAP.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;CS1591</NoWarn>
   </PropertyGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
+	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+	  <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+	<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+	<PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    
   </ItemGroup>
  
 </Project>

--- a/src/DotNetCore.CAP/Internal/IProcessingServer.cs
+++ b/src/DotNetCore.CAP/Internal/IProcessingServer.cs
@@ -12,7 +12,7 @@ namespace DotNetCore.CAP.Internal
     /// </summary>
     public interface IProcessingServer : IDisposable
     {
-        void Pulse() { }
+        void Pulse();
 
         void Start(CancellationToken stoppingToken);
     }

--- a/src/DotNetCore.CAP/Internal/MethodMatcherCache.cs
+++ b/src/DotNetCore.CAP/Internal/MethodMatcherCache.cs
@@ -67,7 +67,7 @@ namespace DotNetCore.CAP.Internal
         /// <param name="groupName">The group name of the value to get.</param>
         /// <param name="matchTopic">topic executor of the value.</param>
         /// <returns>true if the key was found, otherwise false. </returns>
-        public bool TryGetTopicExecutor(string topicName, string groupName, [NotNullWhen(true)] out ConsumerExecutorDescriptor? matchTopic)
+        public bool TryGetTopicExecutor(string topicName, string groupName, out ConsumerExecutorDescriptor? matchTopic)
         {
             if (Entries == null)
             {

--- a/src/DotNetCore.CAP/Messages/TransportMessage.cs
+++ b/src/DotNetCore.CAP/Messages/TransportMessage.cs
@@ -30,12 +30,12 @@ namespace DotNetCore.CAP.Messages
 
         public string GetId()
         {
-            return Headers[Messages.Headers.MessageId]!;
+            return Headers.TryGetValue(Messages.Headers.MessageId, out var value) ? value! : "Unknown";
         }
 
         public string GetName()
         {
-            return Headers[Messages.Headers.MessageName]!;
+            return Headers.TryGetValue(Messages.Headers.MessageName, out var value) ? value! : "";
         }
 
         public string? GetGroup()

--- a/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.Default.cs
@@ -173,6 +173,8 @@ namespace DotNetCore.CAP.Processor
             }
         }
 
+        public void Pulse() { }
+
         public void Dispose()
         {
             if (!_cts.IsCancellationRequested)

--- a/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
+++ b/src/DotNetCore.CAP/Processor/IDispatcher.PerGroup.cs
@@ -203,6 +203,8 @@ namespace DotNetCore.CAP.Processor
             }
         }
 
+        public void Pulse() { }
+
         public void Dispose()
         {
             if (!_cts.IsCancellationRequested)

--- a/src/DotNetCore.CAP/Transport/IConsumerClient.cs
+++ b/src/DotNetCore.CAP/Transport/IConsumerClient.cs
@@ -22,10 +22,7 @@ namespace DotNetCore.CAP.Transport
         /// </summary>
         /// <param name="topicNames">Names of the requested topics</param>
         /// <returns>Topic identifiers</returns>
-        ICollection<string> FetchTopics(IEnumerable<string> topicNames)
-        {
-            return topicNames.ToList();
-        }
+        ICollection<string> FetchTopics(IEnumerable<string> topicNames);
 
         /// <summary>
         /// Subscribe to a set of topics to the message queue

--- a/test/DotNetCore.CAP.Test/FakeInMemoryQueue/InMemoryConsumerClient.cs
+++ b/test/DotNetCore.CAP.Test/FakeInMemoryQueue/InMemoryConsumerClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Transport;
@@ -28,6 +29,11 @@ namespace DotNetCore.CAP.Test.FakeInMemoryQueue
         public event EventHandler<LogMessageEventArgs> OnLog;
 
         public BrokerAddress BrokerAddress => new BrokerAddress("InMemory", string.Empty);
+
+        public ICollection<string> FetchTopics(IEnumerable<string> topicNames)
+        {
+            return topicNames.ToList();
+        }
 
         public void Subscribe(IEnumerable<string> topics)
         {


### PR DESCRIPTION
Make the CAP library usable from .NET Framework projects. Also, a minor change so CAP doesn't get infinitely stuck if the incoming queue contains messages without CAP headers.

Changes:
- Update csproj files' target frameworks, and also use the target-specific version of Entity Framework (note, database projects explicitly support net472 because there seems to be an issue in nuget that means framework projects think they need the .NETStandard2.1 dependencies unless there's a framework-specific version of the nuget package)
- Remove\pragma C#8+ features
    - [NotNullWhen] tags
    - Methods implementations defined on the interface
    - Pragma around the different features available in different EntityFramework versions
    - Add pragmas to suppress unavoidable warnings (e.g. that the NetStandard2.0 version of a method has no async content)
- Add alternative way to get IBootstrapper running in the background (since .NET Framework just ignores IHostedService)
    - Make Bootstrapper class public and add StartIfNotAlreadyRunning method and support
    - Let ConsumingAssembly be specified in options because Assembly.EntryAssembly() doesn't find the right result when Bootstrapper triggered manually
- Add sample .NET Framework project
- Add null checks around getting headers on a received message