### PR TITLE
When using RedisStreams only one ConsumerGroup is created 

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<VersionMajor>6</VersionMajor>
 		<VersionMinor>2</VersionMinor>
-		<VersionPatch>0</VersionPatch>
+		<VersionPatch>1</VersionPatch>
 		<VersionQuality></VersionQuality>
 		<VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
 	</PropertyGroup>

--- a/src/DotNetCore.CAP.RedisStreams/IRedisStream.Manager.Extensions.cs
+++ b/src/DotNetCore.CAP.RedisStreams/IRedisStream.Manager.Extensions.cs
@@ -66,6 +66,9 @@ namespace DotNetCore.CAP.RedisStreams
                 var groupInfo = await database.StreamGroupInfoAsync(stream);
                 if (groupInfo.Any(g => g.Name == consumerGroup))
                     return;
+                
+                await database.StreamCreateConsumerGroupAsync(stream, consumerGroup, StreamPosition.NewMessages)
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixed RedisStream.Manager.Extensions.TryGetOrCreateStreamGroupAsync to create ConsumerGroup when not found.