### PR TITLE
Fixed typo.

### DIFF
--- a/docs/content/user-guide/en/monitoring/diagnostics.md
+++ b/docs/content/user-guide/en/monitoring/diagnostics.md
@@ -75,7 +75,7 @@ process-id： The ID of the CAP process to collect counter data from.
 
 ### Monitor with dashboard
 
-You can configure `x.UserDashboard()` to open the dashboard to view Metrics graph charts.
+You can configure `x.UseDashboard()` to open the dashboard to view Metrics graph charts.
 
 ![img](/img/dashboard-metrics.gif)
 

--- a/docs/content/user-guide/zh/monitoring/diagnostics.md
+++ b/docs/content/user-guide/zh/monitoring/diagnostics.md
@@ -69,7 +69,7 @@ dotnet-counters monitor --process-id=25496 --counters=DotNetCore.CAP.EventCounte
 
 ### 在 Dashboard 中查看度量
 
-你可以配置 `x.UserDashboard()` 来开启仪表盘以图表的形式查看 Metrics 指标。 如下图：
+你可以配置 `x.UseDashboard()` 来开启仪表盘以图表的形式查看 Metrics 指标。 如下图：
 
 ![img](/img/dashboard-metrics.gif)
 


### PR DESCRIPTION
Fixed typo on page [Diagnostics => Dashboard](https://cap.dotnetcore.xyz/user-guide/en/monitoring/diagnostics/#monitor-with-dashboard).

`x.UserDashboard() ==> x.UseDashboard()`