### PR TITLE
add basicQos options to control the basic channel of RabbitMq and enforce qos parameters

### DIFF
--- a/samples/Sample.RabbitMQ.SqlServer/Startup.cs
+++ b/samples/Sample.RabbitMQ.SqlServer/Startup.cs
@@ -27,6 +27,9 @@ namespace Sample.RabbitMQ.SqlServer
                     y.UserName = "user";
                     y.Password = "pass";
                     y.HostName = "localhost:5672,localhost:5673,localhost:5674";
+                    //If BasicQosOptions are created then the basic channel will use the qos settings, otherwise will ignore BasicQos 
+                    //In the case below will enforce a prefetchCount of max 3 messages unacknowledged to be consumed
+                    y.BasicQosOptions = new DotNetCore.CAP.RabbitMQOptions.BasicQos(3);
                 });
                 x.UseDashboard();
                 x.FailedRetryCount = 5;

--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -118,35 +118,17 @@ namespace DotNetCore.CAP
         }
                 
         public class BasicQos
-        {
+        {       
             /// <summary>
-            /// New intance of BasicQos sets the use of basic qos setup on the channel.
-            /// </summary>
-            /// <param name="prefetchCount">Sets the PrefetchSize.</param>
+            /// New instance of BasicQos sets the use of basic qos setup on the basic channel.
+            /// </summary>            
+            /// <param name="prefetchCount">Sets the PrefetchCount.</param>
             /// <param name="global">Sets Global flag (default false).</param>
             public BasicQos(ushort prefetchCount, bool global = false)
             {
                 PrefetchCount = prefetchCount;
-            }
-
-            /// <summary>
-            /// New intance of BasicQos sets the use of basic qos setup on the channel.
-            /// </summary>
-            /// <param name="prefetchSize">Sets the PrefetchSize.</param>
-            /// <param name="prefetchCount">Sets the PrefetchCount.</param>
-            /// <param name="global">Sets Global flag (default false).</param>
-            public BasicQos(uint prefetchSize, ushort prefetchCount, bool global = false)
-            {
-                PrefetchSize = prefetchSize;
-                PrefetchCount = prefetchCount;
                 Global = global;
-            }            
-
-            /// <summary>
-            /// Gets the PrefetchSize, a value of 0 is treated as infinite, allowing any number of unacknowledged message to be prefetched on server. 
-            /// The default value is 0.
-            /// </summary>
-            public uint PrefetchSize { get; private set; } = 0;
+            }   
 
             /// <summary>
             /// Gets the PrefetchCount, a value of 0 is treated as infinite, allowing any number of unacknowledged message being pushed to consumer.

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -68,7 +68,7 @@ namespace DotNetCore.CAP.RabbitMQ
             consumer.ConsumerCancelled += OnConsumerConsumerCancelled;
 
             if (_rabbitMQOptions.BasicQosOptions != null)
-                _channel?.BasicQos(_rabbitMQOptions.BasicQosOptions.PrefetchSize, _rabbitMQOptions.BasicQosOptions.PrefetchCount, _rabbitMQOptions.BasicQosOptions.Global);
+                _channel?.BasicQos(0, _rabbitMQOptions.BasicQosOptions.PrefetchCount, _rabbitMQOptions.BasicQosOptions.Global);
 
             _channel.BasicConsume(_queueName, false, consumer);
 

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -67,6 +67,9 @@ namespace DotNetCore.CAP.RabbitMQ
             consumer.Unregistered += OnConsumerUnregistered;
             consumer.ConsumerCancelled += OnConsumerConsumerCancelled;
 
+            if (_rabbitMQOptions.BasicQosOptions != null)
+                _channel?.BasicQos(_rabbitMQOptions.BasicQosOptions.PrefetchSize, _rabbitMQOptions.BasicQosOptions.PrefetchCount, _rabbitMQOptions.BasicQosOptions.Global);
+
             _channel.BasicConsume(_queueName, false, consumer);
 
             while (true)


### PR DESCRIPTION
feature: add basicQos options to control the basic channel of RabbitMq and enforce qos parameters.

This feature is a much needed option and a simple one to implement for RabbitMQ control of the basicQos channel.

The reason why the need for this setup:in my opinion is a much needed option due to the fact that sometimes we need to control the flow of the messages consumed to allow for lesser memory footprint on some big queues with some big messages workload that cannot be coped with the rabbit speed of delivery to consume those messages.

I would like to know if is possible to add this change also from at least 6.2.1 as there are still some projects in the .net 6 version?

Thanks to: @rafaelpadovezi / @ricardochaves  helping sorting this out