### PR TITLE
Added option to set the queue type for RabbitMQ

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -115,6 +115,11 @@ namespace DotNetCore.CAP
             /// </summary>
             // ReSharper disable once InconsistentNaming
             public int MessageTTL { get; set; } = 864000000;
+
+            /// <summary>
+            /// Gets or sets queue type by supplying the 'x-queue-type' declaration argument with a string specifying the desired type.
+            /// </summary>
+            public string QueueType { get; set; } = default!;
         }
                 
         public class BasicQos

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -126,6 +126,11 @@ namespace DotNetCore.CAP.RabbitMQ
                         arguments.Add("x-queue-mode", _rabbitMQOptions.QueueArguments.QueueMode);
                     }
 
+                    if (!string.IsNullOrEmpty(_rabbitMQOptions.QueueArguments.QueueType))
+                    {
+                        arguments.Add("x-queue-type", _rabbitMQOptions.QueueArguments.QueueType);
+                    }
+
                     _channel.QueueDeclare(_queueName, durable: true, exclusive: false, autoDelete: false, arguments: arguments);
                 }
             }


### PR DESCRIPTION
Added an option to change the consumer queue type if required as I needed support for quorum queues.

https://www.rabbitmq.com/quorum-queues.html