### PR TITLE
Allow publishing to multiple Service Bus topics (attempt 2)

### DIFF
--- a/CAP.sln
+++ b/CAP.sln
@@ -86,6 +86,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.OpenTelemetr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.AzureServiceBus.InMemory", "samples\Sample.AzureServiceBus.InMemory\Sample.AzureServiceBus.InMemory.csproj", "{0C734FB2-7D75-4FF3-B564-1E50E6280B14}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCore.CAP.AzureServiceBus.Test", "test\DotNetCore.CAP.AzureServiceBus.Test\DotNetCore.CAP.AzureServiceBus.Test.csproj", "{D9681967-DAC2-43EF-999F-3727F1046711}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -208,6 +210,10 @@ Global
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9681967-DAC2-43EF-999F-3727F1046711}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9681967-DAC2-43EF-999F-3727F1046711}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9681967-DAC2-43EF-999F-3727F1046711}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9681967-DAC2-43EF-999F-3727F1046711}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -242,6 +248,7 @@ Global
 		{B1D95CCD-0123-41D4-8CCB-9F834ED8D5C5} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 		{83DDB126-A00B-4064-86E7-568322CA67EC} = {9B2AE124-6636-4DE9-83A3-70360DABD0C4}
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14} = {3A6B6931-A123-477A-9469-8B468B5385AF}
+		{D9681967-DAC2-43EF-999F-3727F1046711} = {C09CDAB0-6DD4-46E9-B7F3-3EF2A4741EA0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E70565D-94CF-40B4-BFE1-AC18D5F736AB}

--- a/samples/Sample.AzureServiceBus.InMemory/Contracts/DomainEvents/Contract.cs
+++ b/samples/Sample.AzureServiceBus.InMemory/Contracts/DomainEvents/Contract.cs
@@ -1,0 +1,5 @@
+namespace Sample.AzureServiceBus.InMemory.Contracts.DomainEvents;
+
+public record EntityCreated(Guid Id);
+
+public record EntityDeleted(Guid Id);

--- a/samples/Sample.AzureServiceBus.InMemory/Contracts/IntegrationEvents/Contract.cs
+++ b/samples/Sample.AzureServiceBus.InMemory/Contracts/IntegrationEvents/Contract.cs
@@ -1,0 +1,5 @@
+namespace Sample.AzureServiceBus.InMemory.Contracts.IntegrationEvents;
+
+public record EntityCreatedForIntegration(Guid Id);
+
+public record EntityDeletedForIntegration(Guid Id);

--- a/samples/Sample.AzureServiceBus.InMemory/Properties/launchSettings.json
+++ b/samples/Sample.AzureServiceBus.InMemory/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Sample.AzureServiceBus.InMemory": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -182,7 +182,8 @@ namespace DotNetCore.CAP.AzureServiceBus
 
                     var topicPaths = 
                         _asbOptions.CustomProducers.Select(producer => producer.TopicPath)
-                            .Append(_asbOptions.TopicPath);
+                            .Append(_asbOptions.TopicPath)
+                            .Distinct();
 
                     foreach (var topicPath in topicPaths)
                     {

--- a/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Azure.Messaging.ServiceBus;
 using DotNetCore.CAP.AzureServiceBus;
+using DotNetCore.CAP.AzureServiceBus.Producer;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP
@@ -67,5 +68,17 @@ namespace DotNetCore.CAP
         /// https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-filter
         /// </summary>
         public List<KeyValuePair<string,string>>? SQLFilters { get; set; }
+        
+        public AzureServiceBusOptions ConfigureCustomProducer<T>(Action<ServiceBusProducerDescriptorBuilder<T>> configuration)
+        {
+            var builder = new ServiceBusProducerDescriptorBuilder<T>();
+            configuration(builder);
+            CustomProducers.Add(builder.Build());
+
+            return this;
+        }
+
+        internal ICollection<IServiceBusProducerDescriptor> CustomProducers { get; set; } =
+            new List<IServiceBusProducerDescriptor>();
     }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/DotNetCore.CAP.AzureServiceBus.csproj
+++ b/src/DotNetCore.CAP.AzureServiceBus/DotNetCore.CAP.AzureServiceBus.csproj
@@ -23,4 +23,9 @@
   <ItemGroup>
     <ProjectReference Include="..\DotNetCore.CAP\DotNetCore.CAP.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DotNetCore.CAP.AzureServiceBus.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -37,7 +37,8 @@ namespace DotNetCore.CAP.AzureServiceBus
         public BrokerAddress BrokerAddress => new BrokerAddress("AzureServiceBus", _asbOptions.Value.ConnectionString);
 
         /// <summary>
-        /// Gets a custom Producer
+        /// Creates a producer descriptor for the given message. If there's no custom producer configuration for the
+        /// message type, one will be created using defaults configured in the AzureServiceBusOptions (e.g. TopicPath).
         /// </summary>
         /// <param name="transportMessage"></param>
         /// <returns></returns>

--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -46,7 +46,7 @@ namespace DotNetCore.CAP.AzureServiceBus
                    .CustomProducers
                    .SingleOrDefault(p => p.MessageTypeName == transportMessage.GetName())
                ??
-               new ServiceBusProducerDescriptorDescriptor(
+               new ServiceBusProducerDescriptor(
                    typeName: transportMessage.GetName(),
                    topicPath: _asbOptions.Value.TopicPath);
         

--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNetCore.CAP.AzureServiceBus.Producer;
 using Azure.Messaging.ServiceBus;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
@@ -13,7 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.AzureServiceBus
 {
-    internal class AzureServiceBusTransport : ITransport
+    internal class AzureServiceBusTransport : ITransport, IServiceBusProducerDescriptorFactory
     {
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
@@ -21,8 +24,8 @@ namespace DotNetCore.CAP.AzureServiceBus
         private readonly IOptions<AzureServiceBusOptions> _asbOptions;
 
         private ServiceBusClient? _client;
-        private ServiceBusSender? _sender;
-
+        private readonly ConcurrentDictionary<string, ServiceBusSender?> _senders = new();
+        
         public AzureServiceBusTransport(
             ILogger<AzureServiceBusTransport> logger,
             IOptions<AzureServiceBusOptions> asbOptions)
@@ -33,11 +36,26 @@ namespace DotNetCore.CAP.AzureServiceBus
 
         public BrokerAddress BrokerAddress => new BrokerAddress("AzureServiceBus", _asbOptions.Value.ConnectionString);
 
+        /// <summary>
+        /// Gets a custom Producer
+        /// </summary>
+        /// <param name="transportMessage"></param>
+        /// <returns></returns>
+        public IServiceBusProducerDescriptor CreateProducerForMessage(TransportMessage transportMessage)
+            => _asbOptions.Value
+                   .CustomProducers
+                   .SingleOrDefault(p => p.MessageTypeName == transportMessage.GetName())
+               ??
+               new ServiceBusProducerDescriptorDescriptor(
+                   typeName: transportMessage.GetName(),
+                   topicPath: _asbOptions.Value.TopicPath);
+        
         public async Task<OperateResult> SendAsync(TransportMessage transportMessage)
         {
             try
             {
-                Connect();
+                var producer = CreateProducerForMessage(transportMessage);
+                var sender = GetSenderForProducer(producer);
                 
                 var message = new ServiceBusMessage(transportMessage.Body.ToArray())
                 {
@@ -65,7 +83,7 @@ namespace DotNetCore.CAP.AzureServiceBus
                 }
 
                 
-                await _sender!.SendMessageAsync(message);
+                await sender.SendMessageAsync(message);
 
                 _logger.LogDebug($"Azure Service Bus message [{transportMessage.GetName()}] has been published.");
 
@@ -79,11 +97,20 @@ namespace DotNetCore.CAP.AzureServiceBus
             }
         }
 
-        private void Connect()
+
+        /// <summary>
+        /// Gets the Topic Client for the specified producer. If it does not exist, a new one is created and added to the Topic Client dictionary.
+        /// </summary>
+        /// <param name="producerDescriptor"></param>
+        /// <returns><see cref="ServiceBusSender"/></returns>
+        private ServiceBusSender GetSenderForProducer(IServiceBusProducerDescriptor producerDescriptor)
         {
-            if (_client != null)
+            if (_senders.TryGetValue(producerDescriptor.TopicPath, out var sender) && sender != null)
             {
-                return;
+                _logger.LogTrace("Topic {TopicPath} connection already present as a Publish destination.",
+                    producerDescriptor.TopicPath);
+
+                return sender;
             }
 
             _connectionLock.Wait();
@@ -93,7 +120,13 @@ namespace DotNetCore.CAP.AzureServiceBus
                 _client ??= _asbOptions.Value.TokenCredential is null ? new ServiceBusClient(_asbOptions.Value.ConnectionString) :
                                                                          new ServiceBusClient(_asbOptions.Value.Namespace,_asbOptions.Value.TokenCredential);
 
-                _sender ??= _client.CreateSender(_asbOptions.Value.TopicPath);
+                var newSender = _client.CreateSender(producerDescriptor.TopicPath);
+                _senders.AddOrUpdate(
+                    key: producerDescriptor.TopicPath,
+                    addValue: newSender,
+                    updateValueFactory: (_, _) => newSender);
+
+                return newSender;
             }
             finally
             {

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DotNetCore.CAP.AzureServiceBus.Producer;
+
+public interface IServiceBusProducerDescriptor
+{
+    string TopicPath { get; }
+    string MessageTypeName { get; }
+}
+
+public class ServiceBusProducerDescriptorDescriptor : IServiceBusProducerDescriptor
+{
+    public ServiceBusProducerDescriptorDescriptor(Type type, string topicPath)
+    {
+        MessageTypeName = type.Name;
+        TopicPath = topicPath;
+    }
+
+    public ServiceBusProducerDescriptorDescriptor(string typeName, string topicPath)
+    {
+        MessageTypeName = typeName;
+        TopicPath = topicPath;
+    }
+
+    public string TopicPath { get; set; }
+
+    public string MessageTypeName { get; }
+}
+
+public class ServiceBusProducerDescriptorDescriptor<T> : ServiceBusProducerDescriptorDescriptor
+{
+    public ServiceBusProducerDescriptorDescriptor(string topicPath) : base(typeof(T), topicPath)
+    {
+    }
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
@@ -8,15 +8,15 @@ public interface IServiceBusProducerDescriptor
     string MessageTypeName { get; }
 }
 
-public class ServiceBusProducerDescriptorDescriptor : IServiceBusProducerDescriptor
+public class ServiceBusProducerDescriptor : IServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptorDescriptor(Type type, string topicPath)
+    public ServiceBusProducerDescriptor(Type type, string topicPath)
     {
         MessageTypeName = type.Name;
         TopicPath = topicPath;
     }
 
-    public ServiceBusProducerDescriptorDescriptor(string typeName, string topicPath)
+    public ServiceBusProducerDescriptor(string typeName, string topicPath)
     {
         MessageTypeName = typeName;
         TopicPath = topicPath;
@@ -27,9 +27,9 @@ public class ServiceBusProducerDescriptorDescriptor : IServiceBusProducerDescrip
     public string MessageTypeName { get; }
 }
 
-public class ServiceBusProducerDescriptorDescriptor<T> : ServiceBusProducerDescriptorDescriptor
+public class ServiceBusProducerDescriptor<T> : ServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptorDescriptor(string topicPath) : base(typeof(T), topicPath)
+    public ServiceBusProducerDescriptor(string topicPath) : base(typeof(T), topicPath)
     {
     }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptorFactory.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptorFactory.cs
@@ -1,0 +1,8 @@
+using DotNetCore.CAP.Messages;
+
+namespace DotNetCore.CAP.AzureServiceBus.Producer;
+
+public interface IServiceBusProducerDescriptorFactory
+{
+    IServiceBusProducerDescriptor CreateProducerForMessage(TransportMessage transportMessage);
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
@@ -10,8 +10,8 @@ public class ServiceBusProducerDescriptorBuilder<T>
         return this;
     }
 
-    public ServiceBusProducerDescriptorDescriptor<T> Build()
+    public ServiceBusProducerDescriptor<T> Build()
     {
-        return new ServiceBusProducerDescriptorDescriptor<T>(TopicPath);
+        return new ServiceBusProducerDescriptor<T>(TopicPath);
     }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
@@ -1,0 +1,17 @@
+namespace DotNetCore.CAP.AzureServiceBus.Producer;
+
+public class ServiceBusProducerDescriptorBuilder<T>
+{
+    private string TopicPath { get; set; }
+
+    public ServiceBusProducerDescriptorBuilder<T> WithTopic(string topicPath)
+    {
+        TopicPath = topicPath;
+        return this;
+    }
+
+    public ServiceBusProducerDescriptorDescriptor<T> Build()
+    {
+        return new ServiceBusProducerDescriptorDescriptor<T>(TopicPath);
+    }
+}

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/DotNetCore.CAP.AzureServiceBus.Test.csproj
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/DotNetCore.CAP.AzureServiceBus.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\samples\Sample.AzureServiceBus.InMemory\Sample.AzureServiceBus.InMemory.csproj" />
+        <ProjectReference Include="..\..\src\DotNetCore.CAP.AzureServiceBus\DotNetCore.CAP.AzureServiceBus.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/Producer/ServiceBusProducerBuilderTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/Producer/ServiceBusProducerBuilderTests.cs
@@ -1,0 +1,22 @@
+using DotNetCore.CAP.AzureServiceBus.Producer;
+using Shouldly;
+using Xunit;
+
+namespace DotNetCore.CAP.AzureServiceBus.Tests.Producer;
+
+public record MessagePublished;
+
+public class ServiceBusProducerBuilderTests
+{
+    [Fact]
+    public void Should_HavePropertiesCorrectlySet_When_BuildMethodIsExecuted()
+    {
+        var producer = new ServiceBusProducerDescriptorBuilder<MessagePublished>()
+            .WithTopic("my-destination")
+            .Build();
+
+        producer.ShouldNotBeNull();
+        producer.TopicPath.ShouldBe("my-destination");
+        producer.MessageTypeName.ShouldBe(nameof(MessagePublished));
+    }
+}

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using DotNetCore.CAP.Messages;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sample.AzureServiceBus.InMemory.Contracts.DomainEvents;
+using Shouldly;
+using Xunit;
+
+namespace DotNetCore.CAP.AzureServiceBus.Tests;
+
+public class ServiceBusTransportTests
+{
+    private readonly IOptions<AzureServiceBusOptions> _options;
+
+    public ServiceBusTransportTests()
+    {
+        var config = new AzureServiceBusOptions();
+        config.ConfigureCustomProducer<EntityCreated>(cfg => cfg.WithTopic("entity-created"));
+
+        _options = Options.Create(config);
+    }
+
+    [Fact]
+    public void Custom_Producer_Should_Have_Custom_Topic()
+    {
+        // Given
+        var transport = new AzureServiceBusTransport(NullLogger<AzureServiceBusTransport>.Instance, _options);
+
+        var transportMessage = new TransportMessage(
+            headers: new Dictionary<string, string?>()
+            {
+                {Headers.MessageName, nameof(EntityCreated)}
+            },
+            body: null);
+
+        // When
+        var producer = transport.CreateProducerForMessage(transportMessage);
+
+        // Then
+        producer.MessageTypeName.ShouldBe(nameof(EntityCreated));
+        producer.TopicPath.ShouldBe("entity-created");
+    }
+
+    [Fact]
+    public void Default_Producer_Should_Have_Default_Topic()
+    {
+        // Given
+        var transport = new AzureServiceBusTransport(NullLogger<AzureServiceBusTransport>.Instance, _options);
+
+        var transportMessage = new TransportMessage(
+            headers: new Dictionary<string, string?>()
+            {
+                {Headers.MessageName, nameof(EntityDeleted)}
+            },
+            body: null);
+
+        // When
+        var producer = transport.CreateProducerForMessage(transportMessage);
+
+        // Then
+        producer.MessageTypeName.ShouldBe(nameof(EntityDeleted));
+        producer.TopicPath.ShouldBe(_options.Value.TopicPath);
+    }
+}


### PR DESCRIPTION
This is a continuation of the work that was started by @mviegas in #1139, rebased on top of the latest changes in the master branch. The PR adds the possibility of publishing to multiple Azure Service Bus Topics inside the same Azure Service Bus instance by specifying a custom topic by message type, providing partial support for #1074.

```csharp
    capOptions.UseAzureServiceBus(asb =>
    {
        // other configuration
        asb.ConfigureCustomProducer<EntityCreatedForIntegration>(cfg => cfg.WithTopic("entity-created"));
    });
```

Message types that don't have a custom producer configuration will use the default `TopicPath`. 