### PR TITLE
redundant code in BasicQos

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -139,14 +139,14 @@ namespace DotNetCore.CAP
             /// Gets the PrefetchCount, a value of 0 is treated as infinite, allowing any number of unacknowledged message being pushed to consumer.
             /// The default value is 0.
             /// </summary>
-            public ushort PrefetchCount { get; private set; } = 0;
+            public ushort PrefetchCount { get; private set; }
 
             /// <summary>
             /// Gets the global flag across all consumers in RabbitMq.
             /// false (default) - applied separately to each new consumer on the channel
             /// true - shared across all consumers on the channel
             /// </summary>
-            public bool Global { get; private set; } = false;
+            public bool Global { get; private set; }
         }
     }
 }

--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -139,14 +139,14 @@ namespace DotNetCore.CAP
             /// Gets the PrefetchCount, a value of 0 is treated as infinite, allowing any number of unacknowledged message being pushed to consumer.
             /// The default value is 0.
             /// </summary>
-            public ushort PrefetchCount { get; private set; }
+            public ushort PrefetchCount { get; }
 
             /// <summary>
             /// Gets the global flag across all consumers in RabbitMq.
             /// false (default) - applied separately to each new consumer on the channel
             /// true - shared across all consumers on the channel
             /// </summary>
-            public bool Global { get; private set; }
+            public bool Global { get; }
         }
     }
 }


### PR DESCRIPTION
1. remove redundant default value assignment for properties (54a942e4f31f1cedadf9fa7593a93884081a48cb)
2. remove unused private setters (29f9e4e65dd8931aeb841167db5292d7785e6a04)