### PR TITLE
Fix #1324

### DIFF
--- a/CAP.sln
+++ b/CAP.sln
@@ -89,6 +89,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetCore.CAP.AzureService
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Dashboard.Jwt", "samples\Sample.Dashboard.Jwt\Sample.Dashboard.Jwt.csproj", "{F739A8C9-565F-4B1D-8F91-FEE056C03FBD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCore.CAP.RedisStreams.Test", "test\DotNetCore.CAP.RedisStreams.Test\DotNetCore.CAP.RedisStreams.Test.csproj", "{FA866875-B0E3-4288-869D-A9F63A7340AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -219,6 +221,10 @@ Global
 		{F739A8C9-565F-4B1D-8F91-FEE056C03FBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F739A8C9-565F-4B1D-8F91-FEE056C03FBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F739A8C9-565F-4B1D-8F91-FEE056C03FBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA866875-B0E3-4288-869D-A9F63A7340AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA866875-B0E3-4288-869D-A9F63A7340AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA866875-B0E3-4288-869D-A9F63A7340AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA866875-B0E3-4288-869D-A9F63A7340AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -255,6 +261,7 @@ Global
 		{0C734FB2-7D75-4FF3-B564-1E50E6280B14} = {3A6B6931-A123-477A-9469-8B468B5385AF}
 		{D9681967-DAC2-43EF-999F-3727F1046711} = {C09CDAB0-6DD4-46E9-B7F3-3EF2A4741EA0}
 		{F739A8C9-565F-4B1D-8F91-FEE056C03FBD} = {3A6B6931-A123-477A-9469-8B468B5385AF}
+		{FA866875-B0E3-4288-869D-A9F63A7340AF} = {C09CDAB0-6DD4-46E9-B7F3-3EF2A4741EA0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E70565D-94CF-40B4-BFE1-AC18D5F736AB}

--- a/src/DotNetCore.CAP.RedisStreams/DotNetCore.CAP.RedisStreams.csproj
+++ b/src/DotNetCore.CAP.RedisStreams/DotNetCore.CAP.RedisStreams.csproj
@@ -12,6 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="DotNetCore.CAP.RedisStreams.Test" />
+		
 		<PackageReference Include="StackExchange.Redis" Version="2.6.70" />
 	</ItemGroup>
 

--- a/test/DotNetCore.CAP.RedisStreams.Test/DotNetCore.CAP.RedisStreams.Test.csproj
+++ b/test/DotNetCore.CAP.RedisStreams.Test/DotNetCore.CAP.RedisStreams.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\DotNetCore.CAP.RedisStreams\DotNetCore.CAP.RedisStreams.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/test/DotNetCore.CAP.RedisStreams.Test/RedisConnectionPoolTest.cs
+++ b/test/DotNetCore.CAP.RedisStreams.Test/RedisConnectionPoolTest.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotNetCore.CAP.RedisStreams;
+
+public class RedisConnectionPoolTest
+{
+    [Fact]
+    public async Task ConnectAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging().AddCap(options => options.UseRedis(options =>
+        {
+            options.Configuration = ConfigurationOptions.Parse("localhost,abortConnect=false,connectTimeout=500");
+            options.ConnectionPoolSize = (uint)Random.Shared.Next(2, 5);
+        }));
+
+        await using var buildServiceProvider = services.BuildServiceProvider();
+        await using var scope = buildServiceProvider.CreateAsyncScope();
+
+        var connectionPool = scope.ServiceProvider.GetRequiredService<IRedisConnectionPool>();
+
+        for (long index = scope.ServiceProvider.GetRequiredService<IOptions<CapRedisOptions>>().Value.ConnectionPoolSize + 1; index >= 0; index--)
+        {
+            Assert.NotNull(await connectionPool.ConnectAsync());
+        }
+    }
+}


### PR DESCRIPTION
## Title: Fix #1324

### Description:
.NET not support Task compare/OrderBy.

#### Issue(s) addressed:
- https://github.com/dotnetcore/CAP/issues/1324

#### Changes:
- Use custom code to OrderBy Task<T>

#### Affected components:
- RedisStream

#### How to test:
``` C#
var array = new[]
{
    Task.Delay(1000).ContinueWith(_ => 1000), Task.Delay(2000).ContinueWith(_ => 2000), Task.Delay(3000).ContinueWith(_ => 2000), Task.Delay(4000).ContinueWith(_ => 300), Task.Delay(5000).ContinueWith(_ => 4000),
};

Console.WriteLine(await array.OrderBy(async t => await t).First());
```

### Additional notes (optional):

### Checklist:
- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [ ] My changes follow the project's code style guidelines

### Reviewers:
- 