### PR TITLE
Azure Service Bus: subscription autodelete on idle

### DIFF
--- a/docs/content/user-guide/en/transport/azure-service-bus.md
+++ b/docs/content/user-guide/en/transport/azure-service-bus.md
@@ -39,16 +39,17 @@ public void ConfigureServices(IServiceCollection services)
 
 The AzureServiceBus configuration options provided directly by the CAP:
 
-| NAME                    | DESCRIPTION                                                                                                                                 | TYPE                                                 | DEFAULT |
-| :---------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | :------ |
-| ConnectionString        | Endpoint address                                                                                                                            | string                                               |
-| EnableSessions          | Enable [Service bus sessions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions)                                | bool                                                 | false   |
-| TopicPath               | Topic entity path                                                                                                                           | string                                               | cap     |
-| ManagementTokenProvider | Token provider                                                                                                                              | ITokenProvider                                       | null    |
-| AutoCompleteMessages    | Gets a value that indicates whether the processor should automatically complete messages after the message handler has completed processing | bool                                                 | false   |
-| CustomHeaders           | Adds custom and/or mandatory Headers for incoming messages from heterogeneous systems.                                                      | `Func<Message, List<KeyValuePair<string, string>>>?` | null    |
-| Namespace               | Namespace of Servicebus , Needs to be set when using with TokenCredential Property                                                          | string                                               | null    |
-| SQLFilters              | Custom SQL Filters by name and expression on Topic Subscribtion                                                                             | List<KeyValuePair<string, string>>                   | null    |
+| NAME                         | DESCRIPTION                                                                                                                                 | TYPE                                                 | DEFAULT           |
+| :----------------------      | :------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | :---------------- |
+| ConnectionString             | Endpoint address                                                                                                                            | string                                               |                   |
+| EnableSessions               | Enable [Service bus sessions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions)                                | bool                                                 | false             |
+| TopicPath                    | Topic entity path                                                                                                                           | string                                               | cap               |
+| SubscriptionAutoDeleteOnIdle | Automatically delete subscription after a certain idle interval.                                                                            | TimeSpan                                             | TimeSpan.MaxValue |
+| ManagementTokenProvider      | Token provider                                                                                                                              | ITokenProvider                                       | null              |
+| AutoCompleteMessages         | Gets a value that indicates whether the processor should automatically complete messages after the message handler has completed processing | bool                                                 | false             |
+| CustomHeaders                | Adds custom and/or mandatory Headers for incoming messages from heterogeneous systems.                                                      | `Func<Message, List<KeyValuePair<string, string>>>?` | null              |
+| Namespace                    | Namespace of Servicebus , Needs to be set when using with TokenCredential Property                                                          | string                                               | null              |
+| SQLFilters                   | Custom SQL Filters by name and expression on Topic Subscribtion                                                                             | List<KeyValuePair<string, string>>                   | null              |
 
 #### Sessions
 

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -198,7 +198,8 @@ namespace DotNetCore.CAP.AzureServiceBus
                             var subscriptionDescription =
                                 new CreateSubscriptionOptions(topicPath, _subscriptionName)
                                 {
-                                    RequiresSession = _asbOptions.EnableSessions
+                                    RequiresSession = _asbOptions.EnableSessions,
+                                    AutoDeleteOnIdle = _asbOptions.SubscriptionAutoDeleteOnIdle
                                 };
 
                             await _administrationClient.CreateSubscriptionAsync(subscriptionDescription);

--- a/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
@@ -42,6 +42,12 @@ namespace DotNetCore.CAP
         public string TopicPath { get; set; } = DefaultTopicPath;
 
         /// <summary>
+        /// The <see cref="TimeSpan"/> idle interval after which the subscription is automatically deleted.
+        /// </summary>
+        /// <remarks>The minimum duration is 5 minutes. Default value is <see cref="TimeSpan.MaxValue"/>.</remarks>
+        public TimeSpan SubscriptionAutoDeleteOnIdle { get; set; } = TimeSpan.MaxValue;
+
+        /// <summary>
         /// Gets a value that indicates whether the processor should automatically complete messages after the message handler has completed processing.
         /// If the message handler triggers an exception, the message will not be automatically completed.
         /// </summary>


### PR DESCRIPTION
### Description:
When creating a topic subscription an AutoDeleteOnIdle timeout can be configured. This PR exposes this option in the CAP AzureServiceBusOptions.

#### Issue(s) addressed:
- https://github.com/dotnetcore/CAP/issues/1347

#### Changes:
- Add `SubscriptionAutoDeleteOnIdle` option to the `AzureServiceBusOptions`
- Pass option in the `AzureServiceBusConsumerClient` when creating a subscription.
#### Affected components:
- DotNetCore.CAP.AzureServiceBus

#### How to test:
_Provide a step-by-step guide on how to test your changes. Include any relevant information like environment setup, dependencies, etc._

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
