### PR TITLE
Adding facade to enable session processing

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -215,7 +215,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
                     }
                 }
 
-                _serviceBusProcessor = _asbOptions.EnableSessions
+                _serviceBusProcessor = !_asbOptions.EnableSessions
                     ? new ServiceBusProcessorFacade(
                         _serviceBusClient.CreateProcessor(_asbOptions.TopicPath, _subscriptionName))
                     : new ServiceBusProcessorFacade(

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -26,7 +26,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
 
     private ServiceBusAdministrationClient? _administrationClient;
     private ServiceBusClient? _serviceBusClient;
-    private ServiceBusProcessor? _serviceBusProcessor;
+    private ServiceBusProcessorFacade? _serviceBusProcessor;
 
     public AzureServiceBusConsumerClient(
         ILogger logger,
@@ -100,6 +100,15 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
     {
         ConnectAsync().GetAwaiter().GetResult();
 
+        if (_serviceBusProcessor!.IsSessionProcessor)
+        {
+            _serviceBusProcessor!.ProcessSessionMessageAsync += _serviceBusProcessor_ProcessSessionMessageAsync;
+        }
+        else
+        {
+            _serviceBusProcessor!.ProcessMessageAsync += _serviceBusProcessor_ProcessMessageAsync;
+        }
+
         _serviceBusProcessor!.ProcessMessageAsync += _serviceBusProcessor_ProcessMessageAsync;
         _serviceBusProcessor.ProcessErrorAsync += _serviceBusProcessor_ProcessErrorAsync;
 
@@ -110,8 +119,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
     {
         var commitInput = (AzureServiceBusConsumerCommitInput)sender!;
         if (_serviceBusProcessor?.AutoCompleteMessages ?? false)
-            commitInput.ProcessMessageArgs.CompleteMessageAsync(commitInput.ProcessMessageArgs.Message).GetAwaiter()
-                .GetResult();
+            commitInput.CompleteMessageAsync().GetAwaiter().GetResult();
     }
 
     public void Reject(object? sender)
@@ -144,6 +152,13 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
     }
 
     private async Task _serviceBusProcessor_ProcessMessageAsync(ProcessMessageEventArgs arg)
+    {
+        var context = ConvertMessage(arg.Message);
+
+        await OnMessageCallback!(context, new AzureServiceBusConsumerCommitInput(arg));
+    }
+
+    private async Task _serviceBusProcessor_ProcessSessionMessageAsync(ProcessSessionMessageEventArgs arg)
     {
         var context = ConvertMessage(arg.Message);
 
@@ -200,15 +215,18 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
                     }
                 }
 
-                _serviceBusProcessor = _serviceBusClient.CreateProcessor(_asbOptions.TopicPath, _subscriptionName,
-                    _asbOptions.EnableSessions
-                        ? new ServiceBusProcessorOptions
-                        {
-                            AutoCompleteMessages = _asbOptions.AutoCompleteMessages,
-                            MaxConcurrentCalls = _asbOptions.MaxConcurrentCalls,
-                            MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30)
-                        }
-                        : null);
+                _serviceBusProcessor = _asbOptions.EnableSessions
+                    ? new ServiceBusProcessorFacade(
+                        _serviceBusClient.CreateProcessor(_asbOptions.TopicPath, _subscriptionName))
+                    : new ServiceBusProcessorFacade(
+                        serviceBusSessionProcessor: _serviceBusClient.CreateSessionProcessor(_asbOptions.TopicPath,
+                            _subscriptionName,
+                            new ServiceBusSessionProcessorOptions
+                            {
+                                AutoCompleteMessages = _asbOptions.AutoCompleteMessages,
+                                MaxConcurrentCallsPerSession = _asbOptions.MaxConcurrentCalls,
+                                MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30),
+                            }));
             }
         }
         finally

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 
 namespace DotNetCore.CAP.AzureServiceBus;
@@ -12,5 +13,20 @@ public class AzureServiceBusConsumerCommitInput
         ProcessMessageArgs = processMessageEventArgs;
     }
 
-    public ProcessMessageEventArgs ProcessMessageArgs { get; set; }
+    public AzureServiceBusConsumerCommitInput(ProcessSessionMessageEventArgs processSessionMessageArgs)
+    {
+        ProcessSessionMessageArgs = processSessionMessageArgs;
+    }
+
+    private ProcessMessageEventArgs? ProcessMessageArgs { get; }
+    private ProcessSessionMessageEventArgs? ProcessSessionMessageArgs { get; }
+
+    private ServiceBusReceivedMessage Message => ProcessMessageArgs?.Message ?? ProcessSessionMessageArgs!.Message;
+
+    public Task CompleteMessageAsync()
+    {
+        return ProcessMessageArgs != null
+            ? ProcessMessageArgs.CompleteMessageAsync(Message)
+            : ProcessSessionMessageArgs!.CompleteMessageAsync(Message);
+    }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/ServiceBusProcessorFacade.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ServiceBusProcessorFacade.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Core Community. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+
+namespace DotNetCore.CAP.AzureServiceBus;
+
+public class ServiceBusProcessorFacade : IAsyncDisposable
+{
+    private readonly ServiceBusProcessor? _serviceBusProcessor;
+    private readonly ServiceBusSessionProcessor? _serviceBusSessionProcessor;
+
+    public bool IsSessionProcessor { get; }
+
+    public bool IsProcessing => IsSessionProcessor
+        ? _serviceBusSessionProcessor!.IsProcessing
+        : _serviceBusProcessor!.IsProcessing;
+
+    public bool AutoCompleteMessages => IsSessionProcessor
+        ? _serviceBusSessionProcessor!.AutoCompleteMessages
+        : _serviceBusProcessor!.AutoCompleteMessages;
+
+    public ServiceBusProcessorFacade(ServiceBusProcessor? serviceBusProcessor = null,
+        ServiceBusSessionProcessor? serviceBusSessionProcessor = null)
+    {
+        if (serviceBusProcessor is null && serviceBusSessionProcessor is null)
+        {
+            throw new ArgumentNullException(nameof(serviceBusProcessor),
+                "Either serviceBusProcessor or serviceBusSessionProcessor must be provided");
+        }
+
+        _serviceBusProcessor = serviceBusProcessor;
+        _serviceBusSessionProcessor = serviceBusSessionProcessor;
+
+        IsSessionProcessor = _serviceBusSessionProcessor is not null;
+    }
+
+    public Task StartProcessingAsync(CancellationToken cancellationToken = default)
+    {
+        return IsSessionProcessor
+            ? _serviceBusSessionProcessor!.StartProcessingAsync(cancellationToken)
+            : _serviceBusProcessor!.StartProcessingAsync(cancellationToken);
+    }
+
+    public event Func<ProcessMessageEventArgs, Task> ProcessMessageAsync
+    {
+        add => _serviceBusProcessor!.ProcessMessageAsync += value;
+
+        remove => _serviceBusProcessor!.ProcessMessageAsync -= value;
+    }
+
+    public event Func<ProcessSessionMessageEventArgs, Task> ProcessSessionMessageAsync
+    {
+        add => _serviceBusSessionProcessor!.ProcessMessageAsync += value;
+
+        remove => _serviceBusSessionProcessor!.ProcessMessageAsync -= value;
+    }
+
+    public event Func<ProcessErrorEventArgs, Task> ProcessErrorAsync
+    {
+        add
+        {
+            if (IsSessionProcessor)
+            {
+                _serviceBusSessionProcessor!.ProcessErrorAsync += value;
+            }
+            else
+            {
+                _serviceBusProcessor!.ProcessErrorAsync += value;
+            }
+        }
+
+        remove
+        {
+            if (IsSessionProcessor)
+            {
+                _serviceBusSessionProcessor!.ProcessErrorAsync -= value;
+            }
+            else
+            {
+                _serviceBusProcessor!.ProcessErrorAsync -= value;
+            }
+        }
+    }
+
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_serviceBusProcessor is not null) await _serviceBusProcessor.DisposeAsync();
+        if (_serviceBusSessionProcessor is not null) await _serviceBusSessionProcessor.DisposeAsync();
+    }
+}


### PR DESCRIPTION
### Description:
Having both producer and consumer using CAP on top of Azure Service Bus, both of them having sessions enabled. This causes exceptions on consumer side

```
 - Exception: System.InvalidOperationException: It is not possible for an entity that requires sessions to create a non-sessionful message receiver. TrackingId:<private>, SystemTracker:<private>
 For troubleshooting information, see https://aka.ms/azsdk/net/servicebus/exceptions/troubleshoot.
 at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ReceiveMessagesAsyncInternal(Int32 maxMessages, Nullable`1 maxWaitTime, TimeSpan timeout, CancellationToken cancellationToken)
 at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.<>c.<<ReceiveMessagesAsync>b__41_0>d.MoveNext()
 --- End of stack trace from previous location ---
 at Azure.Messaging.ServiceBus.ServiceBusRetryPolicy.RunOperation[T1,TResult](Func`4 operation, T1 t1, TransportConnectionScope scope, CancellationToken cancellationToken, Boolean logRetriesAsVerbose)
 at Azure.Messaging.ServiceBus.ServiceBusRetryPolicy.RunOperation[T1,TResult](Func`4 operation, T1 t1, TransportConnectionScope scope, CancellationToken cancellationToken, Boolean logRetriesAsVerbose)
 at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ReceiveMessagesAsync(Int32 maxMessages, Nullable`1 maxWaitTime, CancellationToken cancellationToken)
 at Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMessagesAsync(Int32 maxMessages, Nullable`1 maxWaitTime, Boolean isProcessor, CancellationToken cancellationToken)
 at Azure.Messaging.ServiceBus.ReceiverManager.ReceiveAndProcessMessagesAsync(CancellationToken cancellationToken)
```
This is happening because of consumer side misconfiguration, for more context please see
https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md#sending-and-receiving-session-messages

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs#L319
https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs#L109C1-L109C22

#### Issue(s) addressed:
https://github.com/dotnetcore/CAP/issues/1397

#### Changes:
This PR addresses and issue by introducing facade over ServiceBusProcessor, it will either use session processor or not, depending on session configuration

#### Affected components:
AzureServiceBusConsumerClient.cs

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
