### PR TITLE
Fix parent span for "Event Persistence" activity trace

### DIFF
--- a/src/DotNetCore.CAP.OpenTelemetry/DiagnosticListener.cs
+++ b/src/DotNetCore.CAP.OpenTelemetry/DiagnosticListener.cs
@@ -44,11 +44,8 @@ internal class DiagnosticListener : IObserver<KeyValuePair<string, object?>>
                 var eventData = (CapEventDataPubStore)evt.Value!;
                 ActivityContext parentContext = default;
 
-                if (Activity.Current != null &&
-                    Activity.Current.Source.Name == "OpenTelemetry.Instrumentation.AspNetCore")
+                if (Activity.Current != null)
                     _contexts.TryAdd(eventData.Message.GetId(), parentContext = Activity.Current.Context);
-                else
-                    Activity.Current = null;
 
                 var activity = ActivitySource.StartActivity("Event Persistence: " + eventData.Operation,
                     ActivityKind.Internal, parentContext);


### PR DESCRIPTION
### Description:
"Event Persistence" span doesn't get context if a parent transaction is running (for example, an http request handled by a controller).
Since .Net 7, OpenTelemetry activity source name have changed to "Microsoft.AspNetCore"
cf https://github.com/open-telemetry/opentelemetry-dotnet/blob/3c2bb7c93dd2e697636479a1882f49bb0c4a362e/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs#L48

To a larger extent, "Event Persistence" span should be linked to a parent activity if exisit


#### Affected components:
- DotNetCore.CAP.OpenTelemetry
