### PR TITLE
Be able to configure if to subscribe to custom producer topic

### DIFF
--- a/samples/Sample.AzureServiceBus.InMemory/Program.cs
+++ b/samples/Sample.AzureServiceBus.InMemory/Program.cs
@@ -33,8 +33,8 @@ builder.Services.AddCap(c =>
             new("IsFromSampleProjectFilter","IsFromSampleProject = 'true'")
         };
 
-        asb.ConfigureCustomProducer<EntityCreatedForIntegration>(cfg => cfg.WithTopic("entity-created"));
-        asb.ConfigureCustomProducer<EntityDeletedForIntegration>(cfg => cfg.WithTopic("entity-deleted"));
+        asb.ConfigureCustomProducer<EntityCreatedForIntegration>(cfg => cfg.UseTopic("entity-created").WithSubscription());
+        asb.ConfigureCustomProducer<EntityDeletedForIntegration>(cfg => cfg.UseTopic("entity-deleted").WithSubscription());
     });
 
     c.UseDashboard();

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -187,12 +187,14 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
                     _serviceBusClient = new ServiceBusClient(_asbOptions.ConnectionString);
                 }
 
-                var topicPaths =
-                    _asbOptions.CustomProducers.Select(producer => producer.TopicPath)
-                        .Append(_asbOptions.TopicPath)
-                        .Distinct();
+                var topicConfigs =
+                    _asbOptions.CustomProducers.Select(producer =>
+                            (topicPaths: producer.TopicPath, subscribe: producer.CreateSubscription))
+                        .Append((topicPaths: _asbOptions.TopicPath, subscribe: true))
+                        .GroupBy(n => n.topicPaths, StringComparer.OrdinalIgnoreCase)
+                        .Select(n => (topicPaths: n.Key, subscribe: n.Max(o => o.subscribe)));
 
-                foreach (var topicPath in topicPaths)
+                foreach (var (topicPath, subscribe) in topicConfigs)
                 {
                     if (!await _administrationClient.TopicExistsAsync(topicPath))
                     {
@@ -200,7 +202,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
                         _logger.LogInformation($"Azure Service Bus created topic: {topicPath}");
                     }
 
-                    if (!await _administrationClient.SubscriptionExistsAsync(topicPath, _subscriptionName))
+                    if (subscribe && !await _administrationClient.SubscriptionExistsAsync(topicPath, _subscriptionName))
                     {
                         var subscriptionDescription =
                             new CreateSubscriptionOptions(topicPath, _subscriptionName)

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
@@ -9,30 +9,34 @@ public interface IServiceBusProducerDescriptor
 {
     string TopicPath { get; }
     string MessageTypeName { get; }
+    bool CreateSubscription { get; }
 }
 
 public class ServiceBusProducerDescriptor : IServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptor(Type type, string topicPath)
+    public ServiceBusProducerDescriptor(Type type, string topicPath, bool createSubscription = true)
     {
         MessageTypeName = type.Name;
         TopicPath = topicPath;
+        CreateSubscription = createSubscription;
     }
 
-    public ServiceBusProducerDescriptor(string typeName, string topicPath)
+    public ServiceBusProducerDescriptor(string typeName, string topicPath, bool createSubscription = true)
     {
         MessageTypeName = typeName;
         TopicPath = topicPath;
+        CreateSubscription = createSubscription;
     }
 
     public string TopicPath { get; set; }
 
     public string MessageTypeName { get; }
+    public bool CreateSubscription { get; internal set; }
 }
 
 public class ServiceBusProducerDescriptor<T> : ServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptor(string topicPath) : base(typeof(T), topicPath)
+    public ServiceBusProducerDescriptor(string topicPath, bool createSubscription = true) : base(typeof(T), topicPath, createSubscription)
     {
     }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
@@ -1,20 +1,37 @@
 // Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 namespace DotNetCore.CAP.AzureServiceBus.Producer;
 
 public class ServiceBusProducerDescriptorBuilder<T>
 {
     private string TopicPath { get; set; } = null!;
+    private bool CreateSubscription { get; set; }
 
+    [Obsolete("Use .UseTopic($topicPath).WithSubscription() for same behavior.")]
     public ServiceBusProducerDescriptorBuilder<T> WithTopic(string topicPath)
+    {
+        TopicPath = topicPath;
+        CreateSubscription = true;
+        return this;
+    }
+
+    public ServiceBusProducerDescriptorBuilder<T> UseTopic(string topicPath)
     {
         TopicPath = topicPath;
         return this;
     }
 
+    public ServiceBusProducerDescriptorBuilder<T> WithSubscription()
+    {
+        CreateSubscription = true;
+        return this;
+    }
+
     public ServiceBusProducerDescriptor<T> Build()
     {
-        return new ServiceBusProducerDescriptor<T>(TopicPath);
+        return new ServiceBusProducerDescriptor<T>(TopicPath, CreateSubscription);
     }
 }

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/Producer/ServiceBusProducerBuilderTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/Producer/ServiceBusProducerBuilderTests.cs
@@ -9,7 +9,7 @@ public record MessagePublished;
 public class ServiceBusProducerBuilderTests
 {
     [Fact]
-    public void Should_HavePropertiesCorrectlySet_When_BuildMethodIsExecuted()
+    public void Should_HavePropertiesCorrectlySet_When_Obsolete_BuildMethodIsExecuted()
     {
         var producer = new ServiceBusProducerDescriptorBuilder<MessagePublished>()
             .WithTopic("my-destination")
@@ -17,6 +17,26 @@ public class ServiceBusProducerBuilderTests
 
         producer.ShouldNotBeNull();
         producer.TopicPath.ShouldBe("my-destination");
+        producer.MessageTypeName.ShouldBe(nameof(MessagePublished));
+    }
+
+    [Theory]
+    [InlineData("my-destination1", true)]
+    [InlineData("my-destination2", false)]
+    public void Should_HavePropertiesCorrectlySet_When_BuildMethodIsExecuted(string topicName, bool subscriptionEnabled)
+    {
+        var builder = new ServiceBusProducerDescriptorBuilder<MessagePublished>()
+            .UseTopic(topicName);
+
+        if (subscriptionEnabled)
+        {
+            builder.WithSubscription();
+        }
+
+        var producer = builder.Build();
+        producer.ShouldNotBeNull();
+        producer.TopicPath.ShouldBe(topicName);
+        producer.CreateSubscription.ShouldBe(subscriptionEnabled);
         producer.MessageTypeName.ShouldBe(nameof(MessagePublished));
     }
 }

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
@@ -18,7 +18,7 @@ public class ServiceBusTransportTests
     public ServiceBusTransportTests()
     {
         var config = new AzureServiceBusOptions();
-        config.ConfigureCustomProducer<EntityCreated>(cfg => cfg.WithTopic("entity-created"));
+        config.ConfigureCustomProducer<EntityCreated>(cfg => cfg.UseTopic("entity-created").WithSubscription());
 
         _options = Options.Create(config);
     }


### PR DESCRIPTION
### Description:
For azure service bus - `.ConfigureCustomProducer` does not imply it would create a new subscription, this PR is intended to introduce a `.WithSubscription` method to explicitly state that a subscription is needed while still maintaining backward compatibility.
Problem with subscription - if there are no suited consumers - CAP with throw exception, consider a scenario where a service consumes from `topic-a` and posts to `topic-b` via `ConfigureCustomProducer`. There are no expectations where service will consume events from `topic-b` so creating subscription is not needed.

#### Changes:
-  Updated `ServiceBusProducerDescriptorBuilder.cs` by introducing `UseTopic` and `WithSubscription` methods while maintaining backward compatibility for `ConfigureCustomProducer` method

#### Affected components:
- `ServiceBusProducerDescriptorBuilder.cs`
-  `AzureServiceBusConsumerClient.cs`

#### How to test:
Run `ServiceBusProducerBuilderTests.cs`

### Checklist:
- [x] I have tested my changes locally
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @mviegas
- @yang-xiaodong
