### PR TITLE
Removing double registration of event handler

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -109,7 +109,6 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
             _serviceBusProcessor!.ProcessMessageAsync += _serviceBusProcessor_ProcessMessageAsync;
         }
 
-        _serviceBusProcessor!.ProcessMessageAsync += _serviceBusProcessor_ProcessMessageAsync;
         _serviceBusProcessor.ProcessErrorAsync += _serviceBusProcessor_ProcessErrorAsync;
 
         _serviceBusProcessor.StartProcessingAsync(cancellationToken).GetAwaiter().GetResult();


### PR DESCRIPTION
### Description:
Removing double registration of event handler for azure service bus

#### Issue(s) addressed:
- Double registration causes errors on opening connection

#### Changes:
- Removed double registration in azure service bus consumer client

#### Affected components:
- AzureServiceBusConsumerClient.cs

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong 
