### PR TITLE
Open telemetry subscriber thows null reference when using azure service bus without connection string

### DIFF
--- a/src/DotNetCore.CAP.OpenTelemetry/DiagnosticListener.cs
+++ b/src/DotNetCore.CAP.OpenTelemetry/DiagnosticListener.cs
@@ -105,7 +105,7 @@ internal class DiagnosticListener : IObserver<KeyValuePair<string, object?>>
                     activity.SetTag("messaging.system", eventData.BrokerAddress.Name);
                     activity.SetTag("messaging.destination", eventData.Operation);
                     activity.SetTag("messaging.destination_kind", "topic");
-                    activity.SetTag("messaging.url", eventData.BrokerAddress.Endpoint!.Replace("-1", "5672"));
+                    activity.SetTag("messaging.url", eventData.BrokerAddress.Endpoint.Replace("-1", "5672"));
                     activity.SetTag("messaging.message_id", eventData.TransportMessage.GetId());
                     activity.SetTag("messaging.message_payload_size_bytes", eventData.TransportMessage.Body.Length);
 
@@ -162,7 +162,7 @@ internal class DiagnosticListener : IObserver<KeyValuePair<string, object?>>
                     activity.SetTag("messaging.system", eventData.BrokerAddress.Name);
                     activity.SetTag("messaging.destination", eventData.Operation);
                     activity.SetTag("messaging.destination_kind", "topic");
-                    activity.SetTag("messaging.url", eventData.BrokerAddress.Endpoint!.Replace("-1", "5672"));
+                    activity.SetTag("messaging.url", eventData.BrokerAddress.Endpoint.Replace("-1", "5672"));
                     activity.SetTag("messaging.message_id", eventData.TransportMessage.GetId());
                     activity.SetTag("messaging.message_payload_size_bytes", eventData.TransportMessage.Body.Length);
 

--- a/src/DotNetCore.CAP/Transport/BrokerAddress.cs
+++ b/src/DotNetCore.CAP/Transport/BrokerAddress.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 
 namespace DotNetCore.CAP.Transport;
@@ -26,12 +27,12 @@ public struct BrokerAddress
     public BrokerAddress(string name, string? endpoint)
     {
         Name = name;
-        Endpoint = endpoint;
+        Endpoint = endpoint ?? String.Empty;
     }
 
     public string Name { get; set; }
 
-    public string? Endpoint { get; set; }
+    public string Endpoint { get; set; }
 
     public override string ToString()
     {


### PR DESCRIPTION
### Description:
Open telemetry diagnostic listener fails when Azure service bus is used without a connection string.
Azure service bus supports automatic connections when using managed identities, so you don't have to specify connection string. Diagnostic listener has this code that throws a null reference as BrokerAddress.Endpoint is null.

#### Issue(s) addressed:
- https://github.com/dotnetcore/CAP/issues/1432

#### Changes:
- BrokerAddress.Endpoint is never null, fallbacks to String.Empty

#### Affected components:
- BrokerAddress.cs

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong 
