### PR TITLE
Make /ping and /health endpoints to allow anonymous requests

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
+++ b/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
@@ -50,7 +50,7 @@ public class RouteActionProvider
         _builder.MapGet(prefixMatch + "/meta", MetaInfo).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapGet(prefixMatch + "/stats", Stats).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapGet(prefixMatch + "/metrics-history", MetricsHistory).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
-        _builder.MapGet(prefixMatch + "/health", Health).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
+        _builder.MapGet(prefixMatch + "/health", Health).AllowAnonymous();
         _builder.MapGet(prefixMatch + "/published/message/{id:long}", PublishedMessageDetails).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapGet(prefixMatch + "/received/message/{id:long}", ReceivedMessageDetails).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapPost(prefixMatch + "/published/requeue", PublishedRequeue).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);

--- a/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
+++ b/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
@@ -61,7 +61,7 @@ public class RouteActionProvider
         _builder.MapGet(prefixMatch + "/nodes", Nodes).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapGet(prefixMatch + "/list-ns", ListNamespaces).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
         _builder.MapGet(prefixMatch + "/list-svc/{namespace}", ListServices).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
-        _builder.MapGet(prefixMatch + "/ping", PingServices).AllowAnonymousIf(_options.AllowAnonymousExplicit, _options.AuthorizationPolicy);
+        _builder.MapGet(prefixMatch + "/ping", PingServices).AllowAnonymous();
     }
 
     public async Task Metrics(HttpContext httpContext)


### PR DESCRIPTION
### Description:
/ping and /health endpoints should allow anonymous requests as they are mainly used for determining if a service contains any cap endpoints

#### Issue(s) addressed:
- Fixes [1471](https://github.com/dotnetcore/CAP/issues/1471)

#### Changes:
- Make /ping endpoint to allow anonymous requests.

#### Affected components:
- Dashboard

#### How to test:
- Call /ping and /health endpoints without authorization metadata (cookies, auth headers, etc.) while authorization is enabled and expect the requests are succeeded.


### Checklist:
- [x] I have tested my changes locally
- [x] I have added the necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x ] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong 
