### PR TITLE
Respect the node port while configuring downstream request (GatewayProxyAgent)

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/GatewayProxy/GatewayProxyAgent.cs
+++ b/src/DotNetCore.CAP.Dashboard/GatewayProxy/GatewayProxyAgent.cs
@@ -148,6 +148,10 @@ public class GatewayProxyAgent
             uriBuilder = new UriBuilder(node.Address + requestPath + queryString);
         else
             uriBuilder = new UriBuilder("http://", node.Address, node.Port, requestPath, queryString);
+        
+        if (node.Port > 0)
+            uriBuilder.Port = node.Port;
+        
         DownstreamRequest.RequestUri = uriBuilder.Uri;
     }
 


### PR DESCRIPTION
### Description:
In the k8n discovery mode service address is split into two parts one is the HTTP address and the other one is the port. So the port is never included in the service address. `GatewayProxyAgent` assumes that if an address starts with `http` it must be a full address and ignores the port and this causes a request to a nonexistent address. This PR fixes the issue by respecting the port info that comes from the node discovery.

#### Affected components:
- Dashboard

#### How to test:
- Use k8n node discovery in a cluster where services run on different ports than 80 and switch from dashboard.

### Checklist:
- [x] I have tested my changes locally
- [x] I have added the necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong 
