### PR TITLE
Allow custom session handle

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/wwwroot/dist/index.html
+++ b/src/DotNetCore.CAP.Dashboard/wwwroot/dist/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="./favicon.ico">
     <title>CAP Dashboard</title>
-    <script type="module" crossorigin src="./assets/index.648aeb94.js"></script>
-    <link rel="stylesheet" href="./assets/index.9a757ea2.css">
+  <script type="module" crossorigin src="./assets/index.648aeb94.js"></script>
+  <link rel="stylesheet" href="./assets/index.9a757ea2.css">
 </head>
 
 <body>

--- a/src/DotNetCore.CAP.Dashboard/wwwroot/dist/index.html
+++ b/src/DotNetCore.CAP.Dashboard/wwwroot/dist/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="./favicon.ico">
     <title>CAP Dashboard</title>
-  <script type="module" crossorigin src="./assets/index.648aeb94.js"></script>
-  <link rel="stylesheet" href="./assets/index.9a757ea2.css">
+    <script type="module" crossorigin src="./assets/index.648aeb94.js"></script>
+    <link rel="stylesheet" href="./assets/index.9a757ea2.css">
 </head>
 
 <body>

--- a/src/DotNetCore.CAP.MongoDB/ICapTransaction.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/ICapTransaction.MongoDB.cs
@@ -90,4 +90,21 @@ public static class CapTransactionExtensions
         var capTrans = publisher.Transaction.Value.Begin(clientSessionHandle, autoCommit);
         return new CapMongoDbClientSessionHandle(capTrans);
     }
+
+    /// <summary>
+    /// Start the CAP transaction with a custom session handle
+    /// </summary>
+    /// <param name="client">The <see cref="IMongoClient" />.</param>
+    /// <param name="clientSessionHandle">The <see cref="IClientSessionHandle" />.</param>
+    /// <param name="publisher">The <see cref="ICapPublisher" />.</param>
+    /// <param name="autoCommit">Whether the transaction is automatically committed when the message is published</param>
+    /// <returns>The <see cref="IClientSessionHandle" /> of MongoDB transaction session object.</returns>
+    public static IClientSessionHandle StartTransaction(this IMongoClient _, IClientSessionHandle clientSessionHandle,
+        ICapPublisher publisher, bool autoCommit = false)
+    {
+        publisher.Transaction.Value =
+            ActivatorUtilities.CreateInstance<MongoDBCapTransaction>(publisher.ServiceProvider);
+        var capTrans = publisher.Transaction.Value.Begin(clientSessionHandle, autoCommit);
+        return new CapMongoDbClientSessionHandle(capTrans);
+    }
 }


### PR DESCRIPTION
### Description:
Adds the ability to provide a custom IClientSessionHandle to the MongoDB data provider

#### Issue(s) addressed:
None

#### Changes:
- Adds another override to StartTransaction of MongoDB provider to allow a custom IClientSessionHandle instead of creating one on the spot.

#### Affected components:
- MongoDB Storage Provider

#### How to test:
Provide a custom IClientSessionHandle to the StartTransaction method

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong
