### PR TITLE
fix(#435): use TryAddSingleton when registering IStorageInitializer to avoid overwriting user configured initialisers

### DIFF
--- a/src/DotNetCore.CAP.InMemoryStorage/CAP.InMemoryCapOptionsExtension.cs
+++ b/src/DotNetCore.CAP.InMemoryStorage/CAP.InMemoryCapOptionsExtension.cs
@@ -4,6 +4,7 @@
 using DotNetCore.CAP.InMemoryStorage;
 using DotNetCore.CAP.Persistence;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP;
@@ -16,6 +17,6 @@ internal class InMemoryCapOptionsExtension : ICapOptionsExtension
 
         services.AddTransient<ICapTransaction, InMemoryCapTransaction>();
         services.AddSingleton<IDataStorage, InMemoryStorage.InMemoryStorage>();
-        services.AddSingleton<IStorageInitializer, InMemoryStorageInitializer>();
+        services.TryAddSingleton<IStorageInitializer, InMemoryStorageInitializer>();
     }
 }

--- a/src/DotNetCore.CAP.MongoDB/CAP.MongoDBCapOptionsExtension.cs
+++ b/src/DotNetCore.CAP.MongoDB/CAP.MongoDBCapOptionsExtension.cs
@@ -25,7 +25,7 @@ public class MongoDBCapOptionsExtension : ICapOptionsExtension
         services.AddSingleton(new CapStorageMarkerService("MongoDB"));
 
         services.AddSingleton<IDataStorage, MongoDBDataStorage>();
-        services.AddSingleton<IStorageInitializer, MongoDBStorageInitializer>();
+        services.TryAddSingleton<IStorageInitializer, MongoDBStorageInitializer>();
 
         services.Configure(_configure);
 

--- a/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlCapOptionsExtension.cs
+++ b/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlCapOptionsExtension.cs
@@ -5,6 +5,7 @@ using System;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.PostgreSql;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
@@ -26,6 +27,6 @@ internal class PostgreSqlCapOptionsExtension : ICapOptionsExtension
         services.AddSingleton<IConfigureOptions<PostgreSqlOptions>, ConfigurePostgreSqlOptions>();
 
         services.AddSingleton<IDataStorage, PostgreSqlDataStorage>();
-        services.AddSingleton<IStorageInitializer, PostgreSqlStorageInitializer>();
+        services.TryAddSingleton<IStorageInitializer, PostgreSqlStorageInitializer>();
     }
 }

--- a/src/DotNetCore.CAP.SqlServer/CAP.SqlServerCapOptionsExtension.cs
+++ b/src/DotNetCore.CAP.SqlServer/CAP.SqlServerCapOptionsExtension.cs
@@ -28,7 +28,7 @@ internal class SqlServerCapOptionsExtension : ICapOptionsExtension
 
         services.AddSingleton<DiagnosticProcessorObserver>();
         services.AddSingleton<IDataStorage, SqlServerDataStorage>();
-        services.AddSingleton<IStorageInitializer, SqlServerStorageInitializer>();
+        services.TryAddSingleton<IStorageInitializer, SqlServerStorageInitializer>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IProcessingServer, DiagnosticRegister>());
 
         services.Configure(_configure);


### PR DESCRIPTION
### Description:
It was not obvious how this feature works. adding a custom IStorageInitializer before calling UseCap is not working as the registration will get overwritten. This is not the case for the MySQL Initializer as this was already using the TryAddSingleton functionality

#### Issue(s) addressed:
- #435 

#### Changes:
- Calling TryAddSingleton when registering IStorageInitializer

#### Affected components:
- InMemoryCapOptionsExtensions
- MongoDBCapOptionsExtensions
- PostgreSqlCapOptionsExtensions
- SqlServerCapOptionsExtensions

### Additional notes (optional):
I noticed that setting a custom IStorageInitializer

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
