### PR TITLE
Allow configuring PostgreSQL using an Npgsql data source

### DIFF
--- a/docs/content/user-guide/en/storage/postgresql.md
+++ b/docs/content/user-guide/en/storage/postgresql.md
@@ -32,10 +32,11 @@ public void ConfigureServices(IServiceCollection services)
 
 #### PostgreSqlOptions
 
-NAME | DESCRIPTION | TYPE | DEFAULT
-:---|:---|---|:---
-Schema | Database schema | string | cap 
-ConnectionString | Database connection string | string | 
+NAME | DESCRIPTION                | TYPE                 | DEFAULT
+:---|:---------------------------|----------------------|:---
+Schema | Database schema            | string               | cap 
+ConnectionString | Database connection string | string               |
+DataSource | [Data source](https://www.npgsql.org/doc/basic-usage.html#data-source) | [NpgsqlDataSource](https://www.npgsql.org/doc/api/Npgsql.NpgsqlDataSource.html) |
 
 ## Publish with transaction
 

--- a/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
+++ b/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
@@ -16,6 +16,7 @@ public class PostgreSqlOptions : EFOptions
     /// <summary>
     /// Gets or sets the database's connection string that will be used to store database entities.
     /// </summary>
+    [Obsolete("Use .DataSource = NpgsqlDataSource.Create(<connectionString>) for same behavior.")]
     public string ConnectionString { get; set; } = default!;
     
     /// <summary>

--- a/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
+++ b/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
@@ -6,6 +6,7 @@ using DotNetCore.CAP.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP;
@@ -16,6 +17,19 @@ public class PostgreSqlOptions : EFOptions
     /// Gets or sets the database's connection string that will be used to store database entities.
     /// </summary>
     public string ConnectionString { get; set; } = default!;
+    
+    /// <summary>
+    /// Gets or sets the Npgsql data source that will be used to store database entities.
+    /// </summary>
+    public NpgsqlDataSource? DataSource { get; set; }
+
+    /// <summary>
+    /// Creates an Npgsql connection from the configured data source.
+    /// </summary>
+    public NpgsqlConnection CreateConnection()
+    {
+        return DataSource != null ? DataSource.CreateConnection() : new NpgsqlConnection(ConnectionString);
+    }
 }
 
 internal class ConfigurePostgreSqlOptions : IConfigureOptions<PostgreSqlOptions>

--- a/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
+++ b/src/DotNetCore.CAP.PostgreSql/CAP.PostgreSqlOptions.cs
@@ -26,7 +26,7 @@ public class PostgreSqlOptions : EFOptions
     /// <summary>
     /// Creates an Npgsql connection from the configured data source.
     /// </summary>
-    public NpgsqlConnection CreateConnection()
+    internal NpgsqlConnection CreateConnection()
     {
         return DataSource != null ? DataSource.CreateConnection() : new NpgsqlConnection(ConnectionString);
     }

--- a/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
@@ -61,7 +61,7 @@ SELECT
     SELECT COUNT(""Id"") FROM {_pubName} WHERE ""StatusName"" = N'Delayed'
 ) AS ""PublishedDelayed"";";
 
-        var connection = new NpgsqlConnection(_options.ConnectionString);
+        var connection = _options.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         var statistics = await connection.ExecuteReaderAsync(sql, async reader =>
         {
@@ -98,7 +98,7 @@ SELECT
         var sqlQuery =
             $"select * from {tableName} where 1=1 {where} order by \"Added\" desc offset @Offset limit @Limit";
 
-        var connection = new NpgsqlConnection(_options.ConnectionString);
+        var connection = _options.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
 
         var count = await connection.ExecuteScalarAsync<int>($"select count(1) from {tableName} where 1=1 {where}",
@@ -182,7 +182,7 @@ SELECT
         var sqlQuery =
             $"select count(\"Id\") from {tableName} where Lower(\"StatusName\") = Lower(@state)";
 
-        var connection = new NpgsqlConnection(_options.ConnectionString);
+        var connection = _options.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteScalarAsync<int>(sqlQuery, new NpgsqlParameter("@state", statusName))
             .ConfigureAwait(false);
@@ -227,7 +227,7 @@ select ""Key"",""Count"" from aggr where ""Key"" >= @minKey and ""Key"" <= @maxK
         };
 
         Dictionary<string, int> valuesMap;
-        var connection = new NpgsqlConnection(_options.ConnectionString);
+        var connection = _options.CreateConnection();
         await using (connection.ConfigureAwait(false))
         {
             valuesMap = await connection.ExecuteReaderAsync(sqlQuery, async reader =>
@@ -264,7 +264,7 @@ select ""Key"",""Count"" from aggr where ""Key"" >= @minKey and ""Key"" <= @maxK
         var sql =
             $@"SELECT ""Id"" AS ""DbId"", ""Content"", ""Added"", ""ExpiresAt"", ""Retries"" FROM {tableName} WHERE ""Id""={id} FOR UPDATE SKIP LOCKED";
 
-        var connection = new NpgsqlConnection(_options.ConnectionString);
+        var connection = _options.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         var mediumMessage = await connection.ExecuteReaderAsync(sql, async reader =>
         {

--- a/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
@@ -46,7 +46,7 @@ public class PostgreSqlStorageInitializer : IStorageInitializer
         if (cancellationToken.IsCancellationRequested) return;
 
         var sql = CreateDbTablesScript(_options.Value.Schema);
-        var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+        var connection = _options.Value.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         object[] sqlParams =
         {


### PR DESCRIPTION

### Description:
Add an optional DataSource property in the PostgreSqlOptions. Using a data source will allow users of CAP to configure the full range of Npgsql options without having to expose each one in the CAP API. In particular, this allows to configure [dynamic password rotation](https://www.npgsql.org/doc/security.html#auth-token-rotation-and-dynamic-password) needed when authenticating against certain databases hosted in the cloud.

#### Issue(s) addressed:
- #1310

#### Changes:
- Allow configuration of `NpgsqlDataSource` through a new `DataSource` property in `PostgreSqlOptions`.
- Create `NpgsqlConnection` from data source if there is one, otherwise fall back to using the connection string

#### Affected components:
- PostgresSQL

#### How to test:
The new data source configuration can be tested like this:

```csharp
        var dataSource = new NpgsqlDataSourceBuilder(connectionString).Build();

        services.AddCap(capOptions =>
            capOptions
                // other CAP config
                .UsePostgreSql(opts => opts.DataSource = dataSource);
            )
```

My motivation for creating this PR was to allow CAP to be used with a PostgreSQL database hosted in Azure and authenticated via Azure managed identity (this requires configuring a password provider on the data source since the password tokens expire). In order to test this specific setup you need an Azure account with Entra ID and an Azure PostgreSQL server that has been configured to [sign in with Entra](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication).

An example of how to use an Azure credential to a get an access token to use as a database password is provided by Microsoft [here](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-connect-with-managed-identity#connect-using-managed-identity-in-c).

The remaining piece is to configure the data source with a password provider that refreshes that token:

```csharp
        dataSourceBuilder.UsePeriodicPasswordProvider(...); // password callback fetching a new access token from Azure
```

### Additional notes (optional):
`PostgreSqlOptions.ConnectionString` has been kept for backwards compatibility, removing it would be a breaking change. In the future, it might not be necessary to have both DataSource and ConnectionString in PostgreSqlOptions.

The [data source concept](https://www.npgsql.org/doc/basic-usage.html#data-source) was introduced in Npgsql 7.0 and is now the recommended way to create connections. Direct instantiation of a NpgsqlConnection is still supported, but [discouraged](https://www.npgsql.org/doc/basic-usage.html#connections-without-a-data-source).

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ ] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong 
