### PR TITLE
Adding default publish headers

### DIFF
--- a/docs/content/user-guide/en/cap/configuration.md
+++ b/docs/content/user-guide/en/cap/configuration.md
@@ -144,6 +144,12 @@ The expiration time (in seconds) of the failed message. When the message is sent
 
 If `true` then all consumers within the same group pushes received messages to own dispatching pipeline channel. Each channel has set thread count to `ConsumerThreadCount` value.
 
+#### DefaultPublishHeaders
+
+> Default: Dictionary<string, string>.Empty
+
+When populated - automatically adds these headers to all outgoing messages, never overrides any existing default headers.
+
 #### EnableConsumerPrefetch
 
 > Default: false， Before version 7.0 the default behavior is true

--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -111,6 +111,11 @@ public class CapOptions
     public bool UseDispatchingPerGroup { get; set; }
 
     /// <summary>
+    /// Headers to be added to the message when it is published.
+    /// </summary>
+    public IDictionary<string, string> DefaultPublishHeaders { get; } = new Dictionary<string, string>();
+
+    /// <summary>
     /// Configure the retry processor to pick up the backtrack time window for Scheduled or Failed status messages.
     /// Default is 240 seconds.
     /// </summary>

--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -149,6 +149,14 @@ internal class CapPublisher : ICapPublisher
             headers.Add(Headers.SentTime, publishTime.ToString());
         }
 
+        foreach (var defaultPublishHeader in _capOptions.DefaultPublishHeaders)
+        {
+            if (!headers.ContainsKey(defaultPublishHeader.Key))
+            {
+                headers.Add(defaultPublishHeader.Key, defaultPublishHeader.Value);
+            }
+        }
+
         var message = new Message(headers, value);
 
         long? tracingTimestamp = null;


### PR DESCRIPTION
### Description:
A case when you need to add specific custom header to each message - it's not possible at the moment.
Added `DefaultPublishHeaders` dictionary that gets added to all published messages.

#### Changes:
* Added `DefaultPublishHeaders` dictionary to CAP.Options
* In `CapPublisher.Default` collection gets added to headers, existing headers are never overriden

#### Affected components:
* `ICapPublisher.Default`

### Checklist:
- [ x] I have tested my changes locally
- [ x] I have added necessary documentation (if applicable)
- [] I have updated the relevant tests (if applicable)
- [x ] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong
@mviegas 
