### PR TITLE
Fix: Transaction is nullified after finishing the scope

### DIFF
--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -156,7 +156,7 @@ internal class CapPublisher : ICapPublisher
         {
             tracingTimestamp = TracingBefore(message);
 
-            if (Transaction == null)
+            if (Transaction?.DbTransaction == null)
             {
                 var mediumMessage = await _storage.StoreMessageAsync(name, message).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixed bug that causes CapPublisher to hold finished transactions resulting in incorrect publishing behavior

[Related issue](https://github.com/dotnetcore/CAP/issues/1521)

Changes:
Changed Transaction null check in CapPublisher

It can be tested via Sample.Kafka.PostgreSql. After Moving event publishing outside of transaction scope, event will be sent immediately or with a correct delay (if given).