### PR TITLE
Remove duplicate `ContainsGenericParameters` check for `IsController`

### DIFF
--- a/src/DotNetCore.CAP/Internal/Helper.cs
+++ b/src/DotNetCore.CAP/Internal/Helper.cs
@@ -23,8 +23,7 @@ public static class Helper
 
         if (typeInfo.ContainsGenericParameters) return false;
 
-        return !typeInfo.ContainsGenericParameters
-               && typeInfo.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase);
+        return typeInfo.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase);
     }
 
     public static bool IsComplexType(Type type)


### PR DESCRIPTION
### Description:

Remove duplicate `ContainsGenericParameters` check for `IsController`
