### PR TITLE
Nats improvement 1545

### DIFF
--- a/src/DotNetCore.CAP.NATS/CAP.NATSOptions.cs
+++ b/src/DotNetCore.CAP.NATS/CAP.NATSOptions.cs
@@ -26,6 +26,11 @@ namespace DotNetCore.CAP
         public int ConnectionPoolSize { get; set; } = 10;
 
         /// <summary>
+        /// Allows a nats consumer client to dynamically create a stream and configure the expected subjects on the stream. Defaults to true.
+        /// </summary>
+        public bool EnableSubscriberClientStreamAndSubjectCreation { get; set; } = true;
+
+        /// <summary>
         /// Used to setup all NATs client options
         /// </summary>
         public Options? Options { get; set; }

--- a/src/DotNetCore.CAP.NATS/NATSConsumerClient.cs
+++ b/src/DotNetCore.CAP.NATS/NATSConsumerClient.cs
@@ -123,7 +123,12 @@ namespace DotNetCore.CAP.NATS
                         }
                         catch (Exception e)
                         {
-                            Console.WriteLine(e);
+                            OnLogCallback!(new LogMessageEventArgs()
+                            {
+                                LogType = MqLogType.ConnectError,
+                                Reason = $"An error was encountered when attempting to subscribe to subject: {subject}.{Environment.NewLine}" +
+                                $"{e.Message}"
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
### Description:
With these changes a consumer of the DotNetCore.CAP.NATS nuget package can opt out from allowing a NATS Consumer client to create topics and streams dynamically which enforces each client to be granted "admin" like permissions. To avoid assigning these permissions to each client, a consumer of the nuget package can now opt out from this by specifying NATSOptions property `EnableSubscriberClientStreamAndSubjectCreation` to `false` (defaults to true).

#### Issue(s) addressed:
- #1545 

#### Changes:
- Added new `NATSOptions` property `EnableSubscriberClientStreamAndSubjectCreation` and usage of it in `NatsConsumerClient.FetchTopics` method.
- Added call to `OnLogCallback` with `MqLogType.ConnectError` in order to mark the `ConsumerRegister` as "unhealthy" to allow "subscribe retries" calls to the `NatsConsumerClinet.Subscribe` method in case the server have not yet configured the expected stream before the client tries to subscribe.


#### Affected components:
- `DotNetCore.CAP.NATS`

#### How to test:

1. Start a nats server (with no configured streams)
2. Start application with a cap subscriber on a specific subject/topic
   Configured with NatsOptions `EnableSubscriberClientStreamAndSubjectCreation: false`
3. The client will fail to subscribe since the expected stream does not yet exist.
4. Configure the nats server with expected streams and topics expected by application in step 2
5. The application should subscribe to the now configured streams and topics.

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable) **(xml summary on public api)**
- [ ] I have updated the relevant tests (if applicable) **(No existing tests for CAP)**
- [x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong 
