### PR TITLE
fix: BrokerAddress property in AzureServiceBus transport

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
+using DotNetCore.CAP.AzureServiceBus.Helpers;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Transport;
 using Microsoft.Extensions.Logging;
@@ -48,7 +49,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
 
     public Action<LogMessageEventArgs>? OnLogCallback { get; set; }
 
-    public BrokerAddress BrokerAddress => new("AzureServiceBus", _asbOptions.ConnectionString);
+    public BrokerAddress BrokerAddress => ServiceBusHelpers.GetBrokerAddress(_asbOptions.ConnectionString, _asbOptions.Namespace);
 
     public void Subscribe(IEnumerable<string> topics)
     {

--- a/src/DotNetCore.CAP.AzureServiceBus/Helpers/ServiceBusHelpers.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Helpers/ServiceBusHelpers.cs
@@ -1,0 +1,54 @@
+using System;
+using DotNetCore.CAP.Transport;
+
+namespace DotNetCore.CAP.AzureServiceBus.Helpers;
+
+public static class ServiceBusHelpers
+{
+    public static BrokerAddress GetBrokerAddress(string? connectionString, string? @namespace)
+    {
+        var host = (@namespace, connectionString) switch
+        {
+            _ when string.IsNullOrWhiteSpace(@namespace) && string.IsNullOrWhiteSpace(connectionString)
+                => throw new ArgumentException("Either connection string or namespace are required."),
+            _ when string.IsNullOrWhiteSpace(connectionString)
+                   || (!string.IsNullOrWhiteSpace(@namespace) && !string.IsNullOrWhiteSpace(connectionString))
+                => @namespace!,
+            _ when string.IsNullOrWhiteSpace(@namespace)
+                => TryGetEndpointFromConnectionString(connectionString, out var extractedValue)
+                    ? extractedValue!
+                    : throw new InvalidOperationException("Unable to extract namespace from connection string.")
+        };
+
+        return new BrokerAddress("AzureServiceBus", host);
+    }
+
+
+    private static bool TryGetEndpointFromConnectionString(string? connectionString, out string? @namespace)
+    {
+        @namespace = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+            return false;
+
+        var keyValuePairs = connectionString.Split(';');
+
+        foreach (var kvp in keyValuePairs)
+        {
+            if (!kvp.StartsWith("Endpoint", StringComparison.InvariantCultureIgnoreCase)) continue;
+            
+            var endpointParts = kvp.Split('=');
+
+            if (endpointParts.Length != 2) continue;
+
+            var uri = new Uri(endpointParts[1]);
+            
+            // Namespace is the host part without the .servicebus.windows.net
+            @namespace = uri.Host.Split('.')[0];
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/DotNetCore.CAP.AzureServiceBus/Helpers/ServiceBusHelpers.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Helpers/ServiceBusHelpers.cs
@@ -44,7 +44,7 @@ public static class ServiceBusHelpers
             var uri = new Uri(endpointParts[1]);
             
             // Namespace is the host part without the .servicebus.windows.net
-            @namespace = uri.Host.Split('.')[0];
+            @namespace = uri.ToString();
 
             return true;
         }

--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using DotNetCore.CAP.AzureServiceBus.Helpers;
 using DotNetCore.CAP.AzureServiceBus.Producer;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
@@ -51,7 +52,7 @@ internal class AzureServiceBusTransport : ITransport, IServiceBusProducerDescrip
                    _asbOptions.Value.TopicPath);
     }
 
-    public BrokerAddress BrokerAddress => new("AzureServiceBus", _asbOptions.Value.ConnectionString);
+    public BrokerAddress BrokerAddress => ServiceBusHelpers.GetBrokerAddress(_asbOptions.Value.ConnectionString, _asbOptions.Value.Namespace);
 
     public async Task<OperateResult> SendAsync(TransportMessage transportMessage)
     {

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/Helpers/ServiceBusHelperTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/Helpers/ServiceBusHelperTests.cs
@@ -23,14 +23,14 @@ public class ServiceBusHelpersTests
     {
         // Arrange
         string? connectionString = null;
-        string? @namespace = "mynamespace";
+        string? @namespace = "sb://mynamespace.servicebus.windows.net/";
 
         // Act
         var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
 
         // Assert
         Assert.Equal("AzureServiceBus", result.Name);
-        Assert.Equal("mynamespace", result.Endpoint);
+        Assert.Equal("sb://mynamespace.servicebus.windows.net/", result.Endpoint);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class ServiceBusHelpersTests
 
         // Assert
         Assert.Equal("AzureServiceBus", result.Name);
-        Assert.Equal("mynamespace", result.Endpoint);
+        Assert.Equal("sb://mynamespace.servicebus.windows.net/", result.Endpoint);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class ServiceBusHelpersTests
 
         // Assert
         Assert.Equal("AzureServiceBus", result.Name);
-        Assert.Equal("mynamespace", result.Endpoint);
+        Assert.Equal("sb://mynamespace.servicebus.windows.net/", result.Endpoint);
     }
 
     [Fact]
@@ -95,13 +95,13 @@ public class ServiceBusHelpersTests
     {
         // Arrange
         string? connectionString = "";
-        string? @namespace = "mynamespace";
+        string? @namespace = "sb://mynamespace.servicebus.windows.net/";
 
         // Act
         var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
 
         // Assert
         Assert.Equal("AzureServiceBus", result.Name);
-        Assert.Equal("mynamespace", result.Endpoint);
+        Assert.Equal("sb://mynamespace.servicebus.windows.net/", result.Endpoint);
     }
 }

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/Helpers/ServiceBusHelperTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/Helpers/ServiceBusHelperTests.cs
@@ -1,0 +1,107 @@
+using System;
+using DotNetCore.CAP.AzureServiceBus.Helpers;
+using Xunit;
+
+namespace DotNetCore.CAP.AzureServiceBus.Test.Helpers;
+
+public class ServiceBusHelpersTests
+{
+    [Fact]
+    public void GetBrokerAddress_ShouldThrowArgumentException_WhenBothInputsAreNull()
+    {
+        // Arrange
+        string? connectionString = null;
+        string? @namespace = null;
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace));
+        Assert.Equal("Either connection string or namespace are required.", ex.Message);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldReturnNamespace_WhenConnectionStringIsNull()
+    {
+        // Arrange
+        string? connectionString = null;
+        string? @namespace = "mynamespace";
+
+        // Act
+        var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
+
+        // Assert
+        Assert.Equal("AzureServiceBus", result.Name);
+        Assert.Equal("mynamespace", result.Endpoint);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldReturnExtractedNamespace_WhenNamespaceIsNull()
+    {
+        // Arrange
+        string? connectionString = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=myPolicy;SharedAccessKey=myKey";
+        string? @namespace = null;
+
+        // Act
+        var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
+
+        // Assert
+        Assert.Equal("AzureServiceBus", result.Name);
+        Assert.Equal("mynamespace", result.Endpoint);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldThrowInvalidOperationException_WhenNamespaceExtractionFails()
+    {
+        // Arrange
+        string? connectionString = "InvalidConnectionString";
+        string? @namespace = null;
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace));
+        Assert.Equal("Unable to extract namespace from connection string.", ex.Message);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldReturnNamespace_WhenBothNamespaceAndConnectionStringAreProvided()
+    {
+        // Arrange
+        string? connectionString = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=myPolicy;SharedAccessKey=myKey";
+        string? @namespace = "anothernamespace";
+
+        // Act
+        var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
+
+        // Assert
+        Assert.Equal("AzureServiceBus", result.Name);
+        Assert.Equal("anothernamespace", result.Endpoint);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldReturnExtractedNamespace_WhenConnectionStringIsValidAndNamespaceIsEmpty()
+    {
+        // Arrange
+        string? connectionString = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=myPolicy;SharedAccessKey=myKey";
+        string? @namespace = "";
+
+        // Act
+        var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
+
+        // Assert
+        Assert.Equal("AzureServiceBus", result.Name);
+        Assert.Equal("mynamespace", result.Endpoint);
+    }
+
+    [Fact]
+    public void GetBrokerAddress_ShouldReturnNamespace_WhenConnectionStringIsEmpty()
+    {
+        // Arrange
+        string? connectionString = "";
+        string? @namespace = "mynamespace";
+
+        // Act
+        var result = ServiceBusHelpers.GetBrokerAddress(connectionString, @namespace);
+
+        // Assert
+        Assert.Equal("AzureServiceBus", result.Name);
+        Assert.Equal("mynamespace", result.Endpoint);
+    }
+}

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
@@ -17,14 +17,28 @@ public class ServiceBusTransportTests
 
     public ServiceBusTransportTests()
     {
-        var config = new AzureServiceBusOptions();
+        var config = new AzureServiceBusOptions()
+        {
+            ConnectionString = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=myPolicy;SharedAccessKey=myKey" 
+        };
+        
         config.ConfigureCustomProducer<EntityCreated>(cfg => cfg.UseTopic("entity-created").WithSubscription());
 
         _options = Options.Create(config);
     }
 
     [Fact]
-    public void Custom_Producer_Should_Have_Custom_Topic()
+    public void Transport_ShouldHaveCorrectBrokerAddress()
+    {
+        // Given, When
+        var transport = new AzureServiceBusTransport(NullLogger<AzureServiceBusTransport>.Instance, _options);
+        
+        // Then
+        transport.BrokerAddress.Endpoint.ShouldBe("sb://mynamespace.servicebus.windows.net/");
+    }
+
+    [Fact]
+    public void CustomProducer_ShouldHaveCustomTopic()
     {
         // Given
         var transport = new AzureServiceBusTransport(NullLogger<AzureServiceBusTransport>.Instance, _options);
@@ -45,7 +59,7 @@ public class ServiceBusTransportTests
     }
 
     [Fact]
-    public void Default_Producer_Should_Have_Default_Topic()
+    public void DefaultProducer_ShouldHaveDefaultTopic()
     {
         // Given
         var transport = new AzureServiceBusTransport(NullLogger<AzureServiceBusTransport>.Instance, _options);


### PR DESCRIPTION
### Description:
This PR fixes an issue identified in #1571 where the BrokerAddress property had a wrong value when authenticating with TokenCredential instead of ConnectionString.

#### Issue(s) addressed:
No specific issue was opened.

#### Changes:
- Added:
  - `ServiceBusHelpers` class with helper methods and test class `ServiceBusHelpersTests`.
  - Tests to verify BrokerAddress property in `ServiceBusTransportTests` class.
- Changed:
  - BrokerAddress property getter in classes `AzureServiceBusConsumerClient` and `ITransport.AzureServiceBus`.

#### Affected components:
- Azure Service Bus transport.

#### How to test:
- N/A.

### Additional notes (optional):

### Checklist:
- [X] I have tested my changes locally
- [ ] I have added necessary documentation (non-applicable)
- [X] I have updated the relevant tests
- [X] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong 