### PR TITLE
K8S node discovery with filtering options

### DIFF
--- a/docs/content/user-guide/zh/monitoring/kubernetes.md
+++ b/docs/content/user-guide/zh/monitoring/kubernetes.md
@@ -18,6 +18,25 @@ services.AddCap(x =>
 
 ```
 
+## 使用K8sDiscovery配置
+
+此配置选项用于配置仪表板/节点以默认列出每个 K8s `service` 。如果将此设置为 `true`，则只会列出带有`dotnetcore.cap.visibility: show` 标签的服务。有关标签的更多信息可以在 **Kubernetes 标签配置** 部分找到。
+
+* ShowOnlyExplicitVisibleNodes
+
+> 默认值：false
+
+
+```cs
+services.AddCap(x =>
+{
+    // ...
+    x.UseK8sDiscovery(opt=>{
+      opt.ShowOnlyExplicitVisibleNodes = true;
+    });
+});
+```
+
 组件将会自动检测是否处于集群内部，如果处于集群内部在需要赋予Pod Kubernetes Api 的权限。参考下一章节。
 
 ## 分配 Pod 访问  Kubernetes Api 
@@ -89,6 +108,65 @@ spec:
       port: 80
       targetPort: 80
 ```
+
+从版本 `8.3.0` 及更高版本，您可以使用 `Role` 而不是 `ClusterRole`，以允许仅在仪表板运行的命名空间内发现服务。 Kubernetes 角色在命名空间内拥有有限的管辖权。在上面的示例中，只需删除 ClusterRole 和 ClusterRoleBinding 并改为使用以下内容
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ns-svc-reader
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-pods
+subjects:
+- kind: ServiceAccount
+  name: api-access
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: ns-svc-reader
+  apiGroup: rbac.authorization.k8s.io
+
+```
+
+## Kubernetes 标签配置
+
+可以通过向 kubernetes 服务添加标签来控制仪表板中显示的节点列表。
+
+
+- `dotnetcore.cap.visibility` 标签用于显示或隐藏列表中的服务。
+
+    > 可能的值: show | hide
+
+    > 示例: `dotnetcore.cap.visibility: show` or `dotnetcore.cap.visibility: hide`
+
+默认情况下，每个 k8s 服务都会列出该服务中找到的第一个端口。但是，如果服务上存在更多端口，您可以使用以下标签选择所需的端口：
+
+- `dotnetcore.cap.portName` 标签用于过滤需要的服务端口。
+
+    > 可能的值: string
+
+    > 示例: `dotnetcore.cap.portName: grpc` or `dotnetcore.cap.portName: http`
+
+If not found any port with the given name, it will try to match the next label portIndex
+
+- `dotnetcore.cap.portIndex` 标签用于过滤需要的服务端口。 仅当未设置标签 portName 或设置不匹配的 portName 时，才会考虑此过滤器。
+
+    > 可能的值: 数字表示为字符串 ex: '2' or '14'
+
+    > 示例: `dotnetcore.cap.portIndex: '1'` or `dotnetcore.cap.portIndex: '3'`
+
+  如果提供的索引超出范围，那么它将回退到第一个端口（索引：0）
+
+
 
 ## 独立使用 Dashboard 
 

--- a/src/DotNetCore.CAP.Dashboard.K8s/K8sDiscoveryOptions.cs
+++ b/src/DotNetCore.CAP.Dashboard.K8s/K8sDiscoveryOptions.cs
@@ -14,7 +14,14 @@ public class K8sDiscoveryOptions
     public K8sDiscoveryOptions()
     {
         K8SClientConfig = KubernetesClientConfiguration.BuildDefaultConfig();
+        ShowOnlyExplicitVisibleNodes = true;
     }
 
     public KubernetesClientConfiguration K8SClientConfig { get; set; }
+
+    /// <summary>
+    /// If this is set to TRUE will make all nodes hidden by default. Only kubernetes services 
+    /// with label "dotnetcore.cap.visibility:show" will be listed in the nodes section.
+    /// </summary>
+    public bool ShowOnlyExplicitVisibleNodes { get; set; }
 }

--- a/src/DotNetCore.CAP.Dashboard.K8s/K8sNodeDiscoveryProvider.cs
+++ b/src/DotNetCore.CAP.Dashboard.K8s/K8sNodeDiscoveryProvider.cs
@@ -11,20 +11,21 @@ namespace DotNetCore.CAP.Dashboard.K8s;
 // ReSharper disable once InconsistentNaming
 public class K8sNodeDiscoveryProvider : INodeDiscoveryProvider
 {
+    const string TagPrefix = "dotnetcore.cap";
     private readonly ILogger<ConsulNodeDiscoveryProvider> _logger;
-    private readonly KubernetesClientConfiguration _options;
+    private readonly K8sDiscoveryOptions _options;
 
     public K8sNodeDiscoveryProvider(ILoggerFactory logger, K8sDiscoveryOptions options)
     {
         _logger = logger.CreateLogger<ConsulNodeDiscoveryProvider>();
-        _options = options.K8SClientConfig;
+        _options = options;
     }
 
     public async Task<Node?> GetNode(string svcName, string ns, CancellationToken cancellationToken = default)
     {
         try
         {
-            var client = new Kubernetes(_options);
+            var client = new Kubernetes(_options.K8SClientConfig);
             var service =
                 await client.CoreV1.ReadNamespacedServiceAsync(svcName, ns, cancellationToken: cancellationToken);
 
@@ -50,25 +51,12 @@ public class K8sNodeDiscoveryProvider : INodeDiscoveryProvider
     {
         try
         {
+            ns = _options.K8SClientConfig.Namespace;
+
             if (ns == null) return new List<Node>();
 
-            var client = new Kubernetes(_options);
-            var services = await client.CoreV1.ListNamespacedServiceAsync(ns, cancellationToken: cancellationToken);
-
-            var nodes = new List<Node>();
-            foreach (var service in services.Items)
-            {
-                nodes.Add(new Node
-                {
-                    Id = service.Uid(),
-                    Name = service.Name(),
-                    Address = "http://" + service.Metadata.Name + "." + ns,
-                    Port = service.Spec.Ports?[0].Port ?? 0,
-                    Tags = string.Join(',',
-                        service.Labels()?.Select(x => x.Key + ":" + x.Value) ?? Array.Empty<string>())
-                });
-            }
-
+            var nodes = await ListServices(ns);
+            
             CapCache.Global.AddOrUpdate("cap.nodes.count", nodes.Count, TimeSpan.FromSeconds(60), true);
 
             return nodes;
@@ -85,29 +73,231 @@ public class K8sNodeDiscoveryProvider : INodeDiscoveryProvider
 
     public async Task<List<string>> GetNamespaces(CancellationToken cancellationToken)
     {
-        var client = new Kubernetes(_options);
+        var client = new Kubernetes(_options.K8SClientConfig);
         var namespaces = await client.ListNamespaceAsync(cancellationToken: cancellationToken);
         return namespaces.Items.Select(x => x.Name()).ToList();
     }
 
     public async Task<IList<Node>> ListServices(string? ns = null)
     {
-        var client = new Kubernetes(_options);
+        var client = new Kubernetes(_options.K8SClientConfig);
         var services = await client.CoreV1.ListNamespacedServiceAsync(ns);
 
         var result = new List<Node>();
         foreach (var service in services.Items)
         {
+            IDictionary<string, string> tags = service.Labels();
+
+            var filterResult = FilterNodesByTags(tags);
+
+            if (filterResult.hideNode)
+            {
+                continue;
+            }
+
+            int port = GetPortByNameOrIndex(service, filterResult.filteredPortName, filterResult.filteredPortIndex);
+
             result.Add(new Node
             {
                 Id = service.Uid(),
                 Name = service.Name(),
                 Address = "http://" + service.Metadata.Name + "." + ns,
-                Port = service.Spec.Ports?[0].Port ?? 0,
+                Port = port,
                 Tags = string.Join(',', service.Labels()?.Select(x => x.Key + ":" + x.Value) ?? Array.Empty<string>())
             });
         }
 
         return result;
+    }
+
+
+    /// <summary>
+    /// Given the filters (filterPortName and filterPortIndex) this method will try to find the port 
+    /// filterPortName is checked first and if no port is found by that name filterPortIndex is checked
+    /// Returns 0 if service is null or no port specified in the service 
+    /// Returns the portNumber of the matched port if something is found 
+    /// </summary>
+    /// <param name="service"></param>
+    /// <param name="filterPortName"></param>
+    /// <param name="filterPortIndex"></param>
+    /// <returns></returns>
+    private static int GetPortByNameOrIndex(V1Service? service, string filterPortName, int filterPortIndex)
+    {
+        if (service is null)
+        {
+            return 0;
+        }
+
+        if (service.Spec.Ports is null)
+        {
+            return 0;
+        }
+
+        var result = GetPortByName(service.Spec.Ports, filterPortName);
+        if (result > 0)
+        {
+            return result;
+        }
+
+        result = GetPortByIndex(service.Spec.Ports, filterPortIndex);
+        if (result > 0)
+        {
+            return result;
+        }
+
+        return service.Spec.Ports[0]?.Port ?? 0;
+    }
+
+    /// <summary>
+    /// This method will try to find a port with the specified Index 
+    /// Will Return 0 if index is not found  
+    /// Returns: port number or 0 if not found 
+    /// </summary>
+    /// <param name="servicePorts"></param>
+    /// <param name="filterIndex"></param>
+    /// <returns></returns>
+    private static int GetPortByIndex(IList<V1ServicePort> servicePorts, int filterIndex)
+    {
+
+        var portByIndex = servicePorts.ElementAtOrDefault(filterIndex);
+        if (portByIndex is null)
+        {
+            return 0;
+        }
+
+        return portByIndex.Port;
+    }
+
+    /// <summary>
+    /// This method will try to find a port with the specified name 
+    /// Will Return 0 if none found 
+    /// Returns: port number or 0 if not found 
+    /// </summary>
+    /// <param name="service"></param>
+    /// <param name="portName"></param>
+    /// <returns></returns>
+    private static int GetPortByName(IList<V1ServicePort> servicePorts, string portName)
+    {
+        if (!string.IsNullOrEmpty(portName))
+        {
+            return 0;
+        }
+
+        var portByName = servicePorts.FirstOrDefault(p => p.Name == portName);
+        if (portByName is null)
+        {
+            return 0;
+        }
+
+        return portByName.Port;
+    }
+
+    private record TagFilterResult(bool hideNode, int filteredPortIndex, string filteredPortName);
+
+    private TagFilterResult FilterNodesByTags(IDictionary<string, string> tags)
+    {
+        var isNodeHidden = _options.ShowOnlyExplicitVisibleNodes;
+        var filteredPortIndex = 0; //this the default port index 
+        var filteredPortName = string.Empty; //this the default port index 
+
+        if (tags == null)
+        {
+
+            return new TagFilterResult(isNodeHidden, filteredPortIndex, filteredPortName);
+        }
+
+
+        foreach (var tag in tags)
+        {
+            //look out for dotnetcore.cap tags 
+            //based on value will do conditions 
+            var isCapTag = tag.Key.StartsWith(TagPrefix, StringComparison.InvariantCultureIgnoreCase);
+
+            if (!isCapTag)
+            {
+                continue;
+            }
+
+            string capTagScope = GetTagScope(tag);
+
+            //check for hide Tag
+            if (IsNodeHidden(tag, capTagScope))
+            {
+                return new TagFilterResult(true, filteredPortIndex, filteredPortName);
+            }
+            else
+            {
+                isNodeHidden = false;
+            }
+
+            //check for portIndex-X tag.
+            //If multiple tags with portIndex are found only the last has power
+            var hasNewPort = CheckFilterPortIndex(tag, capTagScope);
+            if (hasNewPort.HasValue)
+            {
+                filteredPortIndex = hasNewPort.Value;
+            }
+
+            //check for portName-X tag.
+            //If multiple tags with portName are found only the last has power
+            if (capTagScope.Equals("portName", StringComparison.InvariantCultureIgnoreCase))
+            {
+                filteredPortName = tag.Value;
+            }
+
+        }
+
+        return new TagFilterResult(isNodeHidden, filteredPortIndex, filteredPortName);
+    }
+
+    private int? CheckFilterPortIndex(KeyValuePair<string, string> tag, string capTagScope)
+    {
+        if (!capTagScope.Equals("portIndex", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return null;
+        }
+
+        var hasPort = int.TryParse(tag.Value, out int filterPort);
+        if (!hasPort)
+        {
+            return null;
+        }
+
+        return filterPort;
+    }
+
+    private bool IsNodeHidden(KeyValuePair<string, string> tag, string capTagScope)
+    {
+        if (!capTagScope.Equals("visibility", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return false;
+        }
+
+        //We will not show the node if the tag value is "dotnetcore.cap.visibility:hide"
+        if (tag.Value.Equals("hide", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return true;
+        }
+
+        //We will not show the node if the K8s Dashboard option is 
+        //ShowOnlyExplicitVisibleNodes=True
+        //and the tag value is NOT "dotnetcore.cap.visibility:show"
+        if (!_options.ShowOnlyExplicitVisibleNodes)
+        {
+            return false;
+        }
+
+        return !tag.Value.Equals("show", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    private string GetTagScope(KeyValuePair<string, string> tag)
+    {
+        var capTagScope = tag.Key.Replace(TagPrefix, "", StringComparison.InvariantCultureIgnoreCase);
+        if (capTagScope.StartsWith("."))
+        {
+            capTagScope = capTagScope.Substring(1);
+        }
+
+        return capTagScope;
     }
 }


### PR DESCRIPTION
### Description:
The K8s discovery was working ok but not great for a real life scenario use case. There were the following problems: 
- The security was not great because if you gave someone (a dev) access to use the dashboard, he could switch to any service inside any namespace in the k8s cluster. 
- There were many services listed in the nodes section and most of those don't even have a CAP so they just bloat the list and give an Error if switched to. 
- The listed services always did use the first found port defined in the k8s-service. This needed to change because sometimes when using tools to create your deployments and k8s-services you cannot control the order of the ports of the service. 

Changes in this PR address the above issues by doing the following measures: 
- Allowing to list nodes without the need for selecting a namespace but just using the namespace where ne dashboard is running. This opens the possibility to create a "ServiceAccount" that has only access inside the particular namespace. This improves the security because now I can give access separately to different developers for different environments that run in different k8s-namespaces. 
- Filter out any not needed service by allowing to blacklist any service by adding ```dotnetcore.cap.visibility: hide```. This was not enough because some services are created by an operator and I could not add the same label to those "rabbit-mq" services because the operator detected changes and replaced them instantly removing the label. This problem resulted in adding the "only whitelisted" mode by adding an option to the k8sDiscoveryOptions. This option shows only services containing the ```dotnetcore.cap.visibility: show``` label. 
- The ports can now be selected by index or by name. This can be done by adding ```dotnetcore.cap.portIndex: '1'``` label on the desired service. If the index is outside of bounds then it will fall back to index 0 as it was. The ports can also be selected by name by using the ```dotnetcore.cap.portName: grpc``` label. The "Find by name" rule is stronger than the index. If no port is found with that name it will fall back to the "Find by Index" rule and after that to index 0 as said earlier. This opens the possibility to add more customization using ne k8s-labels. 

#### Issue(s) addressed:
- not neccessary as I already did the PR 

#### Changes:
- Possibility to filter out (hide) some nodes
- Possibility to show only the desired nodes. Very useful if some services are created by an operator and you cannot add labels to hide those. This "whitelist only" mode can be activated by an option added to the UseK8sDiscovery. 
- Possibility to use another port than the first one in a k8s service. This can be done by adding some labels to the service. You can choose which port to use filtering by name or by index using according labels. 

#### Affected components:
- CAP.Dashboar.K8s

#### How to test:
These changes can only be tested by running a project inside kubernetes. 
After setting up and having some test services in the list try the latter scenarios. 

Scenario 1: Hide a node using label ```dotnetcore.cap.visibility: hide``` on a service. 
- add label to the desired service 
- refresh the CAP dashboard and the service should not appear anymore 

Scenario 2: Hide all nodes if not explicitly shown 

- Register the K8s Discovery with the option ShowOnlyExplicitVisibleNodes=True
  ```C#
  services.UseK8sDiscovery(opt =>{
      opt.ShowOnlyExplicitVisibleNodes = true;
  });
  ```
- Refresh the CAP dashboard and you should see no listed nodes 
- Add the label ```dotnetcore.cap.visibility: show``` to the desired service 
- Refresh the CAP dashboard to see only the desired service to be listed as node. 


### Additional notes (optional):
The GetNodes Method was always returning an empty list because the ns argument was always null in any case. I changed that method to return the list of the services that reside in the namespace of the K8s POD where the dashboard is running. This opens the possibility for the ```api-access``` **ServiceAccount** to not use a **ClusterRole** but only ose a **Role** that has access to the services inside the namespace where the dashboard runs. _This is the only use case needed for my project as we have different namespaces for different enviorments inside the K8s._ 

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines


**Documentation updated.** 

### Reviewers:
- _Mention any reviewers you would like to review your PR. This can be helpful if you know someone who is familiar with the part of the codebase you're working on._
