### PR TITLE
fix(#1583): Call AbandonMessageAsync on Azure Service Bus message when persistence fails to avoid message loss

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -134,7 +134,8 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
 
     public void Reject(object? sender)
     {
-        // ignore
+        var commitInput = (AzureServiceBusConsumerCommitInput)sender!;
+        commitInput.AbandonMessageAsync().GetAwaiter().GetResult();
     }
 
     public void Dispose()

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerCommitInput.cs
@@ -29,4 +29,11 @@ public class AzureServiceBusConsumerCommitInput
             ? ProcessMessageArgs.CompleteMessageAsync(Message)
             : ProcessSessionMessageArgs!.CompleteMessageAsync(Message);
     }
+
+    public Task AbandonMessageAsync()
+    {
+        return ProcessMessageArgs != null
+            ? ProcessMessageArgs.AbandonMessageAsync(Message)
+            : ProcessSessionMessageArgs!.AbandonMessageAsync(Message);
+    }
 }


### PR DESCRIPTION
### Description:
When using Azure Service Bus, messages are marked as completed even if the system fails to persist the received message to the database.

#### Issue(s) addressed:
- [Azure Service Bus Messages Marked as Completed Even When Persistence Fails](https://github.com/dotnetcore/CAP/issues/1583)

#### Changes:
- Call AbandonMessageAsync on Azure Service Bus message when persistence fails to avoid message loss.

#### Affected components:
- DotNetCore.CAP.AzureServiceBus

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
