### PR TITLE
added control for queue options in RabbitMQ transport

### DIFF
--- a/docs/content/user-guide/en/transport/rabbitmq.md
+++ b/docs/content/user-guide/en/transport/rabbitmq.md
@@ -50,6 +50,7 @@ VirtualHost | Broker virtual host | string | /
 Port | Port | int | -1
 ExchangeName | Default exchange name | string | cap.default.topic
 QueueArguments  | Extra queue `x-arguments` | QueueArgumentsOptions  |  N/A
+QueueOptions  | Change Options for created queue | QueueRabbitOptions  |  { Durable=true, Exclusive=false, AutoDelete=false }
 ConnectionFactoryOptions  |  RabbitMQClient native connection options | ConnectionFactory | N/A
 CustomHeadersBuilder  | Custom subscribe headers |  See the blow |  N/A
 PublishConfirms | Enable [publish confirms](https://www.rabbitmq.com/confirms.html#publisher-confirms) | bool | false

--- a/docs/content/user-guide/zh/transport/rabbitmq.md
+++ b/docs/content/user-guide/zh/transport/rabbitmq.md
@@ -51,6 +51,7 @@ VirtualHost | 虚拟主机 | string | /
 Port | 端口号 | int | -1
 ExchangeName | CAP默认Exchange名称 | string | cap.default.topic
 QueueArguments  | 队列额外参数 x-arguments | QueueArgumentsOptions  |  N/A
+QueueOptions  | 更改已创建队列的选项 | QueueRabbitOptions  |  { Durable=true, Exclusive=false, AutoDelete=false }
 ConnectionFactoryOptions  |  RabbitMQClient原生参数 | ConnectionFactory | N/A
 CustomHeadersBuilder  | 订阅者自定义头信息 |  见下文 |  N/A
 PublishConfirms | 是否启用[发布确认](https://www.rabbitmq.com/confirms.html#publisher-confirms) | bool | false

--- a/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/CAP.RabbiMQOptions.cs
@@ -80,6 +80,13 @@ public class RabbitMQOptions
     /// </summary>
     public QueueArgumentsOptions QueueArguments { get; set; } = new();
 
+
+    /// <summary>
+    /// Optional queue arguments, also known as "x-arguments" because of their field name in the AMQP 0-9-1 protocol,
+    /// is a map (dictionary) of arbitrary key/value pairs that can be provided by clients when a queue is declared.
+    /// </summary>
+    public QueueRabbitOptions QueueOptions { get; set; } = new();
+
     /// <summary>
     /// If you need to get additional native delivery args, you can use this function to write into <see cref="CapHeader" />.
     /// </summary>
@@ -155,4 +162,12 @@ public class RabbitMQOptions
         /// </summary>
         public bool Global { get; }
     }
+
+    public class QueueRabbitOptions
+    {
+        public bool Durable { get; set; } = true;
+        public bool Exclusive { get; set; } = false;
+        public bool AutoDelete { get; set; } = false;
+    }
 }
+

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQConsumerClient.cs
@@ -132,7 +132,7 @@ internal sealed class RabbitMQConsumerClient : IConsumerClient
 
                 try
                 {
-                    _channel.QueueDeclare(_queueName, true, false, false, arguments);
+                    _channel.QueueDeclare(_queueName, _rabbitMQOptions.QueueOptions.Durable, _rabbitMQOptions.QueueOptions.Exclusive, _rabbitMQOptions.QueueOptions.AutoDelete, arguments);
                 }
                 catch (TimeoutException ex)
                 {


### PR DESCRIPTION
### Description:
I have a use case where transient services that are non competing consumers (consumer group GUID) have to use the queue system to get some push events from other services. These queues are created but never deleted when the service stops to come back in a later time. When the service gets back up it creates a new GUID consumer group, so a new queue. For the moment I am manually deleting these using the RabbitMQ management API so each service when starts, checks for queues with 0 consumers. 
My actual solution is hacky and doesn't work every time. 
_With my ugly hacky implementation there is a problem because sometimes when 2 services start up at the same time, each create its queue but the consumers threads haven't connected yet so the queue gets deleted by the other service. This could have a beautiful solution by using the "Auto Delete" feature of RabbitMQ queues so each queue deletes itself if looses all the consumers._ 
I needed to control the queues auto-delete options so I made this PR 

#### Issue(s) addressed:
- did not open issue 

#### Changes:
- added QueueOptions to RabbitMQOptions so you can control AutoDelete of a queue.
- allowed to change also durable and exclusive options  for any future use case 
- left default options as they were 

#### Affected components:
- DotNetCore.CAP.RabbitMQ

#### How to test:
create a rabbitMQ with new options and check those in the management 

### Additional notes (optional):
_Provide any additional notes or context that may be relevant to the changes._

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable) [Not applicable]
- [x] My changes follow the project's code style guidelines

### Reviewers:
- _Mention any reviewers you would like to review your PR. This can be helpful if you know someone who is familiar with the part of the codebase you're working on._
