### PR TITLE
Add default indexes to the database tables during creation

### DIFF
--- a/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
@@ -210,7 +210,7 @@ public class MySqlDataStorage : IDataStorage
         var connection = new MySqlConnection(_options.Value.ConnectionString);
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteNonQueryAsync(
-                $@"DELETE FROM `{table}` WHERE ExpiresAt < @timeout AND (StatusName='{StatusName.Succeeded}' OR StatusName='{StatusName.Failed}') limit @batchCount;",
+                $@"DELETE FROM `{table}` WHERE ExpiresAt < @timeout AND StatusName IN ('{StatusName.Succeeded}','{StatusName.Failed}') LIMIT @batchCount;",
                 null,
                 new MySqlParameter("@timeout", timeout), new MySqlParameter("@batchCount", batchCount))
             .ConfigureAwait(false);
@@ -318,7 +318,7 @@ public class MySqlDataStorage : IDataStorage
         var fourMinAgo = DateTime.Now.Subtract(lookbackSeconds);
         var sql =
             $"SELECT `Id`,`Content`,`Retries`,`Added` FROM `{tableName}` WHERE `Retries`<@Retries " +
-            $"AND `Version`=@Version AND `Added`<@Added AND (`StatusName` = '{StatusName.Failed}' OR `StatusName` = '{StatusName.Scheduled}') LIMIT 200;";
+            $"AND `Version`=@Version AND `Added`<@Added AND `StatusName` IN ('{StatusName.Failed}','{StatusName.Scheduled}') LIMIT 200;";
 
         object[] sqlParams =
         {

--- a/src/DotNetCore.CAP.MySql/IMonitoringApi.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IMonitoringApi.MySql.cs
@@ -87,16 +87,16 @@ SELECT
     {
         var tableName = queryDto.MessageType == MessageType.Publish ? _pubName : _recName;
         var where = string.Empty;
-        if (!string.IsNullOrEmpty(queryDto.StatusName)) where += " and StatusName=@StatusName";
+        if (!string.IsNullOrEmpty(queryDto.StatusName)) where += " AND StatusName=@StatusName";
 
-        if (!string.IsNullOrEmpty(queryDto.Name)) where += " and Name=@Name";
+        if (!string.IsNullOrEmpty(queryDto.Name)) where += " AND Name=@Name";
 
-        if (!string.IsNullOrEmpty(queryDto.Group)) where += " and `Group`=@Group";
+        if (!string.IsNullOrEmpty(queryDto.Group)) where += " AND `Group`=@Group";
 
-        if (!string.IsNullOrEmpty(queryDto.Content)) where += " and Content like CONCAT('%',@Content,'%')";
+        if (!string.IsNullOrEmpty(queryDto.Content)) where += " AND Content LIKE CONCAT('%',@Content,'%')";
 
         var sqlQuery =
-            $"select * from `{tableName}` where 1=1 {where} order by Added desc limit @Limit offset @Offset";
+            $"SELECT * FROM `{tableName}` WHERE 1=1 {where} ORDER BY Added DESC LIMIT @Limit OFFSET @Offset";
 
         object[] sqlParams =
         {
@@ -177,10 +177,10 @@ SELECT
 
     private async ValueTask<int> GetNumberOfMessage(string tableName, string statusName)
     {
-        var sqlQuery = $"select count(Id) from `{tableName}` where StatusName = @state";
+        var sqlQuery = $"SELECT COUNT(Id) FROM `{tableName}` WHERE StatusName = @State";
         var connection = new MySqlConnection(_options.ConnectionString);
         await using var _ = connection.ConfigureAwait(false);
-        return await connection.ExecuteScalarAsync<int>(sqlQuery, new MySqlParameter("@state", statusName))
+        return await connection.ExecuteScalarAsync<int>(sqlQuery, new MySqlParameter("@State", statusName))
             .ConfigureAwait(false);
     }
 
@@ -205,22 +205,22 @@ SELECT
         IDictionary<string, DateTime> keyMaps)
     {
         var sqlQuery = $@"
-SELECT aggr.*
+SELECT Aggr.*
 FROM (
-         SELECT date_format(`Added`, '%Y-%m-%d-%H') AS `Key`,
-                count(id)                              `Count`
+         SELECT DATE_FORMAT(`Added`, '%Y-%m-%d-%H') AS `Key`,
+                COUNT(`Id`) AS `Count`
          FROM `{tableName}`
-         WHERE StatusName = @statusName
-         GROUP BY date_format(`Added`, '%Y-%m-%d-%H')
-     ) aggr
-WHERE `Key` >= @minKey
-  AND `Key` <= @maxKey;";
+         WHERE `StatusName` = @StatusName
+         GROUP BY DATE_FORMAT(`Added`, '%Y-%m-%d-%H')
+     ) AS Aggr
+WHERE `Key` >= @MinKey
+  AND `Key` <= @MaxKey;";
 
         object[] sqlParams =
         {
-            new MySqlParameter("@statusName", statusName),
-            new MySqlParameter("@minKey", keyMaps.Keys.Min()),
-            new MySqlParameter("@maxKey", keyMaps.Keys.Max())
+            new MySqlParameter("@StatusName", statusName),
+            new MySqlParameter("@MinKey", keyMaps.Keys.Min()),
+            new MySqlParameter("@MaxKey", keyMaps.Keys.Max())
         };
 
         Dictionary<string, int> valuesMap;
@@ -258,7 +258,7 @@ WHERE `Key` >= @minKey
 
     private async Task<MediumMessage?> GetMessageAsync(string tableName, long id)
     {
-        var sql = $@"SELECT `Id` as DbId, `Content`,`Added`,`ExpiresAt`,`Retries` FROM `{tableName}` WHERE Id={id};";
+        var sql = $"SELECT `Id` as DbId, `Content`,`Added`,`ExpiresAt`,`Retries` FROM `{tableName}` WHERE Id={id};";
 
         var connection = new MySqlConnection(_options.ConnectionString);
         await using var _ = connection.ConfigureAwait(false);

--- a/src/DotNetCore.CAP.MySql/IStorageInitializer.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IStorageInitializer.MySql.cs
@@ -98,7 +98,8 @@ CREATE TABLE IF NOT EXISTS `{GetReceivedTableName()}` (
   `ExpiresAt` datetime DEFAULT NULL,
   `StatusName` varchar(50) NOT NULL,
   PRIMARY KEY (`Id`),
-  INDEX `IX_ExpiresAt`(`ExpiresAt`)
+  INDEX `IX_Version_ExpiresAt_StatusName` (`Version`, `ExpiresAt`, `StatusName`),
+  INDEX `IX_ExpiresAt_StatusName` (`ExpiresAt`, `StatusName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `{GetPublishedTableName()}` (
@@ -111,9 +112,9 @@ CREATE TABLE IF NOT EXISTS `{GetPublishedTableName()}` (
   `ExpiresAt` datetime DEFAULT NULL,
   `StatusName` varchar(40) NOT NULL,
   PRIMARY KEY (`Id`),
-  INDEX `IX_ExpiresAt`(`ExpiresAt`)
+  INDEX `IX_Version_ExpiresAt_StatusName` (`Version`, `ExpiresAt`, `StatusName`),
+  INDEX `IX_ExpiresAt_StatusName` (`ExpiresAt`, `StatusName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 ";
         if (_capOptions.Value.UseStorageLock)
             batchSql += $@"

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -208,7 +208,7 @@ public class PostgreSqlDataStorage : IDataStorage
         var connection = _options.Value.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteNonQueryAsync(
-                $"DELETE FROM {table} WHERE \"Id\" IN (SELECT \"Id\" FROM {table} WHERE \"ExpiresAt\" < @timeout AND (\"StatusName\"='{StatusName.Succeeded}' OR \"StatusName\"='{StatusName.Failed}') LIMIT @batchCount);",
+                $"DELETE FROM {table} WHERE \"Id\" IN (SELECT \"Id\" FROM {table} WHERE \"ExpiresAt\" < @timeout AND \"StatusName\" IN ('{StatusName.Succeeded}','{StatusName.Failed}') LIMIT @batchCount);",
                 null,
                 new NpgsqlParameter("@timeout", timeout), new NpgsqlParameter("@batchCount", batchCount))
             .ConfigureAwait(false);
@@ -318,7 +318,7 @@ public class PostgreSqlDataStorage : IDataStorage
         var fourMinAgo = DateTime.Now.Subtract(lookbackSeconds);
         var sql =
             $"SELECT \"Id\",\"Content\",\"Retries\",\"Added\" FROM {tableName} WHERE \"Retries\"<@Retries " +
-            $"AND \"Version\"=@Version AND \"Added\"<@Added AND (\"StatusName\"='{StatusName.Failed}' OR \"StatusName\"='{StatusName.Scheduled}') LIMIT 200;";
+            $"AND \"Version\"=@Version AND \"Added\"<@Added AND \"StatusName\" IN ('{StatusName.Failed}','{StatusName.Scheduled}') LIMIT 200;";
 
         object[] sqlParams =
         {

--- a/src/DotNetCore.CAP.SqlServer/IStorageInitializer.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IStorageInitializer.SqlServer.cs
@@ -86,6 +86,12 @@ CREATE TABLE {GetReceivedTableName()}(
 	[Id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+CREATE NONCLUSTERED INDEX [IX_{GetReceivedTableName()}_Version_ExpiresAt_StatusName] ON {GetReceivedTableName()} ([Version] ASC,[ExpiresAt] ASC,[StatusName] ASC) 
+INCLUDE ([Id], [Content], [Retries], [Added])
+
+CREATE NONCLUSTERED INDEX [IX_{GetReceivedTableName()}_ExpiresAt_StatusName] ON {GetReceivedTableName()} ([ExpiresAt] ASC,[StatusName] ASC)
+
 END;
 
 IF OBJECT_ID(N'{GetPublishedTableName()}',N'U') IS NULL
@@ -104,6 +110,12 @@ CREATE TABLE {GetPublishedTableName()}(
 	[Id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+CREATE NONCLUSTERED INDEX [IX_{GetPublishedTableName()}_Version_ExpiresAt_StatusName] ON {GetPublishedTableName()} ([Version] ASC,[ExpiresAt] ASC,[StatusName] ASC) 
+INCLUDE ([Id], [Content], [Retries], [Added])
+
+CREATE NONCLUSTERED INDEX [IX_{GetPublishedTableName()}_ExpiresAt_StatusName] ON {GetPublishedTableName()} ([ExpiresAt] ASC,[StatusName] ASC)
+
 END;
 ";
         if (_capOptions.Value.UseStorageLock)


### PR DESCRIPTION
### Description:

Add table-building default indexes to database storage and adjust query SQL to use optimized indexes.

#### Issue(s) addressed:

- #1599

#### Changes:
-  Table Creation and Queries for SQL Server, MySQL, PostgreSQL

#### Affected components:
- Storage Component

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
