### PR TITLE
refactored mongo initializer

### DIFF
--- a/src/DotNetCore.CAP.MongoDB/IStorageInitializer.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorageInitializer.MongoDB.cs
@@ -95,26 +95,12 @@ public class MongoDBStorageInitializer : IStorageInitializer
 
             CreateIndexModel<ReceivedMessage>[] indexes =
             {
-                new(
-                    builder
-                        .Ascending(x => x.Name), new CreateIndexOptions { Name = nameof(ReceivedMessage.Name) }),
-                new(
-                    builder
-                        .Ascending(x => x.Added), new CreateIndexOptions { Name = nameof(ReceivedMessage.Added) }),
-                new(
-                    builder
-                        .Ascending(x => x.ExpiresAt),
-                    new CreateIndexOptions { Name = nameof(ReceivedMessage.ExpiresAt) }),
-                new(
-                    builder
-                        .Ascending(x => x.StatusName),
-                    new CreateIndexOptions { Name = nameof(ReceivedMessage.StatusName) }),
-                new(
-                    builder
-                        .Ascending(x => x.Retries), new CreateIndexOptions { Name = nameof(ReceivedMessage.Retries) }),
-                new(
-                    builder
-                        .Ascending(x => x.Version), new CreateIndexOptions { Name = nameof(ReceivedMessage.Version) })
+                new(builder.Ascending(x => x.Name)),
+                new(builder.Ascending(x => x.Added)),
+                new(builder.Ascending(x => x.ExpiresAt)),
+                new(builder.Ascending(x => x.StatusName)),
+                new(builder.Ascending(x => x.Retries)),
+                new(builder.Ascending(x => x.Version))
             };
 
             await col.Indexes.CreateManyAsync(indexes, cancellationToken);
@@ -127,29 +113,13 @@ public class MongoDBStorageInitializer : IStorageInitializer
 
             CreateIndexModel<PublishedMessage>[] indexes =
             {
-                new(
-                    builder
-                        .Ascending(x => x.Name), new CreateIndexOptions { Name = nameof(PublishedMessage.Name) }),
-                new(
-                    builder
-                        .Ascending(x => x.Added), new CreateIndexOptions { Name = nameof(PublishedMessage.Added) }),
-                new(
-                    builder
-                        .Ascending(x => x.ExpiresAt),
-                    new CreateIndexOptions { Name = nameof(PublishedMessage.ExpiresAt) }),
-                new(
-                    builder
-                        .Ascending(x => x.StatusName),
-                    new CreateIndexOptions { Name = nameof(PublishedMessage.StatusName) }),
-                new(
-                    builder
-                        .Ascending(x => x.Retries), new CreateIndexOptions { Name = nameof(PublishedMessage.Retries) }),
-                new(
-                    builder
-                        .Ascending(x => x.Version), new CreateIndexOptions { Name = nameof(PublishedMessage.Version) }),
-                new(
-                    builder
-                        .Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt))
+                new(builder.Ascending(x => x.Name)),
+                new(builder.Ascending(x => x.Added)),
+                new(builder.Ascending(x => x.ExpiresAt)),
+                new(builder.Ascending(x => x.StatusName)),
+                new(builder.Ascending(x => x.Retries)),
+                new(builder.Ascending(x => x.Version)),
+                new(builder.Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt))
             };
 
             await col.Indexes.CreateManyAsync(indexes, cancellationToken);


### PR DESCRIPTION
### Description:
Updated mongo initializer to change the way how indexes are created. Included missing index based on mongo Altas recommendations.

#### Changes:
* Indexes are now created using explicit generic
* Removed index existence check, MongoDB does it automatically (https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndexes/#recreating-an-existing-index)
* Removed Background index option, as it was deprecated and is no longer used by MongoDB (https://www.mongodb.com/docs/manual/core/index-creation/#comparison-to-foreground-and-background-builds)
* Added StatusName_1_ExpiresAt_1 index as per MongoDB Atlas performance advisor
![image](https://github.com/user-attachments/assets/5c3cfb17-874d-40da-883c-e6b1387faa56)
* Using default mongodb naming for indexes


#### Affected components:
* MongoDBStorageInitializer

#### How to test:
Run CAP that is using mongodb locally and wait for initializer to kick in

### Additional notes (optional):
Old indexes are gonna be still present on collections, it is advised to clean them up manually as a part of general collection maintenance

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong
@mviegas 
