### PR TITLE
Adding support for BasicNack in the RabbitMQBasicConsumer 

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
@@ -86,6 +86,14 @@ public class RabbitMQBasicConsumer : AsyncDefaultBasicConsumer
         }
     }
 
+    public virtual void BasicAck(ulong deliveryTag)
+    {
+        if (Model.IsOpen)
+            Model.BasicAck(deliveryTag, false);
+
+        Semaphore.Release();
+    }
+
     public virtual void BasicReject(ulong deliveryTag)
     {
         if (Model.IsOpen)
@@ -95,14 +103,6 @@ public class RabbitMQBasicConsumer : AsyncDefaultBasicConsumer
     }
 
     public virtual void BasicNack(ulong deliveryTag)
-    {
-        if (Model.IsOpen)
-            Model.BasicNack(deliveryTag, false, true);
-
-        Semaphore.Release();
-    }
-
-    public void BasicNack(ulong deliveryTag)
     {
         if (Model.IsOpen)
             Model.BasicNack(deliveryTag, false, true);

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
@@ -15,7 +15,7 @@ namespace DotNetCore.CAP.RabbitMQ;
 
 public class RabbitMQBasicConsumer : AsyncDefaultBasicConsumer
 {
-    private readonly SemaphoreSlim _semaphore;
+    protected readonly SemaphoreSlim _semaphore;
     private readonly string _groupName;
     private readonly bool _usingTaskRun;
     private readonly Func<TransportMessage, object?, Task> _msgCallback;
@@ -85,18 +85,26 @@ public class RabbitMQBasicConsumer : AsyncDefaultBasicConsumer
         }
     }
 
-    public void BasicAck(ulong deliveryTag)
+    public virtual void BasicReject(ulong deliveryTag)
     {
         if (Model.IsOpen)
-            Model.BasicAck(deliveryTag, false);
+            Model.BasicReject(deliveryTag, true);
 
         _semaphore.Release();
     }
 
-    public void BasicReject(ulong deliveryTag)
+    public virtual void BasicNack(ulong deliveryTag)
     {
         if (Model.IsOpen)
-            Model.BasicReject(deliveryTag, true);
+            Model.BasicNack(deliveryTag, false, true);
+
+        _semaphore.Release();
+    }
+
+    public void BasicNack(ulong deliveryTag)
+    {
+        if (Model.IsOpen)
+            Model.BasicNack(deliveryTag, false, true);
 
         _semaphore.Release();
     }


### PR DESCRIPTION
### Description:
Added a BasicNack method to the RabbitMQBasicConsumer class besides and similar to the already existing BasicAck and BasicReject. Also made the methods virtual and the the Semaphore protected so the RabbitMQBasicConsumer can be more extensible.

#### Changes:
- Added a BasicNack method to the RabbitMQBasicConsumer class.
- BasicAck, BasicReject and BasicNack  methods are now virtual.
- The Semaphore  in that class is now protected so the derived classes have more flexibility to override the methods.

#### Affected components:
- RabbitMQBasicConsumer 

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
