### PR TITLE
Added ability to provide an OAuthCllback when using kafka with Iam Authentication

### DIFF
--- a/src/DotNetCore.CAP.Kafka/CAP.KafkaOptions.cs
+++ b/src/DotNetCore.CAP.Kafka/CAP.KafkaOptions.cs
@@ -52,6 +52,11 @@ public class KafkaOptions
     public string Servers { get; set; } = default!;
 
     /// <summary>
+    /// The callback to use to refresh the auth token when it expires
+    /// </summary>
+    public Action<Object, string> OAuthCallback { get; set; }
+
+    /// <summary>
     /// If you need to get offset and partition and so on.., you can use this function to write additional header into
     /// <see cref="CapHeader" />
     /// </summary>

--- a/src/DotNetCore.CAP.Kafka/CAP.KafkaOptions.cs
+++ b/src/DotNetCore.CAP.Kafka/CAP.KafkaOptions.cs
@@ -54,7 +54,7 @@ public class KafkaOptions
     /// <summary>
     /// The callback to use to refresh the auth token when it expires
     /// </summary>
-    public Action<Object, string> OAuthCallback { get; set; }
+    public Action<Object, string> OAuthCallback { get; set; } = default!;
 
     /// <summary>
     /// If you need to get offset and partition and so on.., you can use this function to write additional header into

--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -77,8 +77,16 @@ public class ConnectionPool : IConnectionPool, IDisposable
         }
     }
 
-    protected virtual IProducer<string, byte[]> BuildProducer(ProducerConfig config)
+    protected virtual IProducer<string, byte[]> BuildProducer(ProducerConfig config, Action<Object, string>? oAuthCallback)
     {
-        return new ProducerBuilder<string, byte[]>(config).Build();
+        if (oAuthCallback is null)
+        {
+            return new ProducerBuilder<string, byte[]>(config)
+                .Build();
+        }
+        
+        return new ProducerBuilder<string, byte[]>(config)
+            .SetOAuthBearerTokenRefreshHandler(oAuthCallback)
+            .Build();
     }
 }


### PR DESCRIPTION
### Description:
We are currently using AWS msk to host our kafka cluster, and we wish to only allow a specific IAM role to push data. Currently it doesn't seem like this is supported in CAP.kafka as we cannot provide a callback to refresh the token every time it expires

#### Issue(s) addressed:
Didn't create an issue

#### Changes:
Just added the ability to add a callback to kafka options and if it is provided we use it to register a callback when we create the producer

#### Affected components:
Cap.Kafka

#### How to test:
To setup add the following kafka options:

 kafkaOptions.MainConfig.Add("security.protocol", "sasl_ssl");
 kafkaOptions.MainConfig.Add("sasl.mechanism", "OAUTHBEARER");
 kafkaOptions.OAuthCallback = OauthCallback;

When running the application you will notice the Oauthcallback function gets called
### Additional notes (optional):
_Provide any additional notes or context that may be relevant to the changes._

### Checklist:
- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ ] My changes follow the project's code style guidelines

### Reviewers:
- _Mention any reviewers you would like to review your PR. This can be helpful if you know someone who is familiar with the part of the codebase you're working on._
