### PR TITLE
feat: Add option for valid time range to delete expired messages

### DIFF
--- a/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
+++ b/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
+using DotNetCore.CAP.Options;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.Extensions.Options;
@@ -151,6 +152,10 @@ internal class InMemoryStorage : IDataStorage
     public Task<int> DeleteExpiresAsync(string table, DateTime timeout, int batchCount = 1000,
         CancellationToken token = default)
     {
+        if (_capOptions.Value.DeleteExpiredMessagesValidTimeRange is not null &&
+            !_capOptions.Value.DeleteExpiredMessagesValidTimeRange.CurrentTimeIsValid())
+            return Task.FromResult(0);
+
         var removed = 0;
         if (table == nameof(PublishedMessages))
         {

--- a/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
+using DotNetCore.CAP.Options;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.Extensions.Options;
@@ -226,6 +227,10 @@ public class MongoDBDataStorage : IDataStorage
     public async Task<int> DeleteExpiresAsync(string collection, DateTime timeout, int batchCount = 1000,
         CancellationToken cancellationToken = default)
     {
+        if (_capOptions.Value.DeleteExpiredMessagesValidTimeRange is not null &&
+            !_capOptions.Value.DeleteExpiredMessagesValidTimeRange.CurrentTimeIsValid())
+            return 0;
+
         if (collection == _options.Value.PublishedCollection)
         {
             var publishedCollection = _database.GetCollection<PublishedMessage>(_options.Value.PublishedCollection);

--- a/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
+using DotNetCore.CAP.Options;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -207,6 +208,10 @@ public class MySqlDataStorage : IDataStorage
     public async Task<int> DeleteExpiresAsync(string table, DateTime timeout, int batchCount = 1000,
         CancellationToken token = default)
     {
+        if (_capOptions.Value.DeleteExpiredMessagesValidTimeRange is not null &&
+            !_capOptions.Value.DeleteExpiredMessagesValidTimeRange.CurrentTimeIsValid())
+            return 0;
+
         var connection = new MySqlConnection(_options.Value.ConnectionString);
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteNonQueryAsync(

--- a/src/DotNetCore.CAP.NATS/CAP.NATSOptions.cs
+++ b/src/DotNetCore.CAP.NATS/CAP.NATSOptions.cs
@@ -33,7 +33,7 @@ public class NATSOptions
     /// <summary>
     /// Used to setup all NATs client options
     /// </summary>
-    public Options? Options { get; set; }
+    public global::NATS.Client.Options? Options { get; set; }
 
     public Action<StreamConfiguration.StreamConfigurationBuilder>? StreamOptions { get; set; }
 

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
+using DotNetCore.CAP.Options;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -205,6 +206,10 @@ public class PostgreSqlDataStorage : IDataStorage
     public async Task<int> DeleteExpiresAsync(string table, DateTime timeout, int batchCount = 1000,
         CancellationToken token = default)
     {
+        if (_capOptions.Value.DeleteExpiredMessagesValidTimeRange is not null &&
+            !_capOptions.Value.DeleteExpiredMessagesValidTimeRange.CurrentTimeIsValid())
+            return 0;
+
         var connection = _options.Value.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteNonQueryAsync(

--- a/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
+using DotNetCore.CAP.Options;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.Data.SqlClient;
@@ -205,6 +206,10 @@ public class SqlServerDataStorage : IDataStorage
     public async Task<int> DeleteExpiresAsync(string table, DateTime timeout, int batchCount = 1000,
         CancellationToken token = default)
     {
+        if (_capOptions.Value.DeleteExpiredMessagesValidTimeRange is not null &&
+            !_capOptions.Value.DeleteExpiredMessagesValidTimeRange.CurrentTimeIsValid())
+            return 0;
+
         var connection = new SqlConnection(_options.Value.ConnectionString);
         await using var _ = connection.ConfigureAwait(false);
         return await connection.ExecuteNonQueryAsync(

--- a/src/DotNetCore.CAP/CAP.Options.cs
+++ b/src/DotNetCore.CAP/CAP.Options.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using DotNetCore.CAP.Messages;
+using DotNetCore.CAP.Options;
 
 // ReSharper disable InconsistentNaming
 
@@ -149,6 +150,11 @@ public class CapOptions
     /// if true,cap will use only one instance to retry failure messages
     /// </summary>
     public bool UseStorageLock { get; set; }
+
+    /// <summary>
+    /// If this value is set, workers will delete expired messages only within the specified time ranges.
+    /// </summary>
+    public DeleteExpiredMessagesValidTimeRange? DeleteExpiredMessagesValidTimeRange { get; set; }
 
     /// <summary>
     /// Registers an extension that will be executed when building services.

--- a/src/DotNetCore.CAP/Options/DeleteExpiredMessagesValidTimeRange.cs
+++ b/src/DotNetCore.CAP/Options/DeleteExpiredMessagesValidTimeRange.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace DotNetCore.CAP.Options
+{
+    public class DeleteExpiredMessagesValidTimeRange
+    {
+        public DeleteExpiredMessagesValidTimeRange(TimeSpan fromHour, TimeSpan toHour)
+        {
+            FromHour = fromHour;
+            ToHour = toHour;
+
+            ThrowExceptionIfTimeRangeIsNotValid();
+        }
+
+        public TimeSpan FromHour { get; private set; }
+        public TimeSpan ToHour { get; private set; }
+
+        void ThrowExceptionIfTimeRangeIsNotValid()
+        {
+            if (FromHour >= ToHour)
+                throw new ArgumentException("FromHour must be less than ToHour.");
+        }
+    }
+
+    public static class DeleteExpiredMessagesValidTimeRangeExtension
+    {
+        /// <summary>
+        /// Checks if the current time of day falls within the valid range.
+        /// </summary>
+        /// <param name="timeRange">The time range to check against.</param>
+        /// <returns>Returns true if the current time is within the valid range; otherwise, false.</returns>
+        public static bool CurrentTimeIsValid(this DeleteExpiredMessagesValidTimeRange timeRange)
+        {
+            var now = DateTime.Now.TimeOfDay;
+            return now >= timeRange.FromHour && now <= timeRange.ToHour;
+        }
+    }
+}

--- a/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
+++ b/test/DotNetCore.CAP.AzureServiceBus.Test/ServiceBusTransportTests.cs
@@ -24,7 +24,7 @@ public class ServiceBusTransportTests
         
         config.ConfigureCustomProducer<EntityCreated>(cfg => cfg.UseTopic("entity-created").WithSubscription());
 
-        _options = Options.Create(config);
+        _options = Microsoft.Extensions.Options.Options.Create(config);
     }
 
     [Fact]


### PR DESCRIPTION
•  Introduced a new configuration option to specify a valid time range for deleting expired messages.

•  Updated the deletion logic to respect the configured time range, allowing deletions to occur only during specified hours (e.g., 1 AM to 6 AM).

•  This change helps to avoid database locks during high load periods.


### Description:
This PR introduces a new configuration option to specify a valid time range for deleting expired messages. The deletion logic has been updated to respect the configured time range, allowing deletions to occur only during specified hours (e.g., 1 AM to 6 AM). This change helps to avoid database locks during high load periods.

#### Issue(s) addressed:
- [](https://github.com/dotnetcore/CAP/issues/1613)

#### Affected components:
- CAP.Options and IDataStorage

#### How to test:
- Configure the valid time range for deleting expired messages in the settings and verify that messages are only deleted within the specified time range.

### Checklist:
- [✓] I have tested my changes locally
- [✓] I have added necessary documentation (if applicable)
- [✓] I have updated the relevant tests (if applicable)
- [✓] My changes follow the project's code style guidelines
