### PR TITLE
Handle existing cap-msg-group header and tolerate duplicate headers for Kafka consumer

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
@@ -111,7 +111,7 @@ internal sealed class AmazonSQSConsumerClient : IConsumerClient
 
                     var message = new TransportMessage(header, body != null ? Encoding.UTF8.GetBytes(body) : null);
 
-                    message.Headers.Add(Headers.Group, _groupId);
+                    message.Headers[Headers.Group] = _groupId;
 
                     return OnMessageCallback!(message, response.Messages[0].ReceiptHandle);
                 }

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -278,7 +278,7 @@ internal sealed class AzureServiceBusConsumerClient : IConsumerClient
         var headers = message.ApplicationProperties
             .ToDictionary(x => x.Key, y => y.Value?.ToString());
 
-        headers.Add(Headers.Group, _subscriptionName);
+        headers[Headers.Group] = _subscriptionName;
 
         if (_asbOptions.CustomHeadersBuilder != null)
         {

--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -171,10 +171,10 @@ public class KafkaConsumerClient : IConsumerClient
         foreach (var header in consumerResult.Message.Headers)
         {
             var val = header.GetValueBytes();
-            headers.Add(header.Key, val != null ? Encoding.UTF8.GetString(val) : null);
+            headers[header.Key] = val != null ? Encoding.UTF8.GetString(val) : null;
         }
 
-        headers.Add(Headers.Group, _groupId);
+        headers[Headers.Group] = _groupId;
 
         if (_kafkaOptions.CustomHeadersBuilder != null)
         {

--- a/src/DotNetCore.CAP.NATS/NATSConsumerClient.cs
+++ b/src/DotNetCore.CAP.NATS/NATSConsumerClient.cs
@@ -166,7 +166,7 @@ internal sealed class NATSConsumerClient : IConsumerClient
                 headers.Add(h, e.Message.Header[h]);
             }
 
-            headers.Add(Headers.Group, _groupName);
+            headers[Headers.Group] = _groupName;
 
             if (_natsOptions.CustomHeadersBuilder != null)
             {

--- a/src/DotNetCore.CAP.Pulsar/PulsarConsumerClient.cs
+++ b/src/DotNetCore.CAP.Pulsar/PulsarConsumerClient.cs
@@ -78,7 +78,7 @@ internal sealed class PulsarConsumerClient : IConsumerClient
                         headers.Add(header.Key, header.Value);
                     }
 
-                    headers.Add(Headers.Group, _groupId);
+                    headers[Headers.Group] = _groupId;
 
                     var message = new TransportMessage(headers, consumerResult.Data);
 

--- a/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/RabbitMQBasicConsumer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Messages;
@@ -67,7 +68,7 @@ public class RabbitMQBasicConsumer : AsyncDefaultBasicConsumer
                         headers.Add(header.Key, header.Value?.ToString());
                 }
 
-            headers.Add(Messages.Headers.Group, _groupName);
+            headers[Messages.Headers.Group] = _groupName;
 
             if (_customHeadersBuilder != null)
             {


### PR DESCRIPTION
### Description:
Handle existing cap-msg-group header (by overwriting it) and tolerate duplicate headers for Kafka consumer (since testers tend to do stuff manually sometimes and mess up with message headers as well)

#### Issue(s) addressed:
- https://github.com/dotnetcore/CAP/issues/1620

#### How to test:
Produce a message to Kafka or any other supported system with cap-msg-group header

### Checklist:
- [ ✓] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ ✓] My changes follow the project's code style guidelines
