### PR TITLE
feat: cap subscribe existing ef transaction

### DIFF
--- a/src/DotNetCore.CAP.SqlServer/ICapTransaction.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/ICapTransaction.SqlServer.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Data;
-using System.Data.Common;
-using System.Threading;
-using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.SqlServer.Diagnostics;
@@ -15,6 +10,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP;
@@ -138,6 +138,17 @@ public static class CapTransactionExtensions
         publisher.Transaction.DbTransaction = dbTransaction;
         publisher.Transaction.AutoCommit = autoCommit;
         return new CapEFDbTransaction(publisher.Transaction);
+    }
+
+    /// <summary>
+    /// Subscribe cap publisher to an existing entity framework transaction
+    /// </summary>
+    /// <param name="transaction">The <see cref="IDbContextTransaction" />.</param>
+    /// <param name="publisher">The <see cref="ICapPublisher" />.</param>
+    public static void SubscribeCap(this IDbContextTransaction transaction, ICapPublisher publisher)
+    {
+        publisher.Transaction = ActivatorUtilities.CreateInstance<SqlServerCapTransaction>(publisher.ServiceProvider);
+        publisher.Transaction.DbTransaction = transaction.GetDbTransaction();
     }
 
     /// <summary>


### PR DESCRIPTION
### Description:
This PR will add a new function in SQL server transaction that makes the user be able to make cap publisher subscribe to an existing entity framework transaction which has a good motivation.
The motivation is to let the user begin a scoped transaction anywhere in the request and let cap subscribe to this transaction later on this is beneficial when having an interceptor on entity framework save changes which may have an enclosing transaction, as a result of entity framework and SQL doesn't support nested transaction so you have to reuse the same transaction that is opened in the scoped context

#### Issue(s) addressed:
- no issue addressed

#### Changes:
- Added an extension method in ICapTransaction.SqlServer named SubscribeCap on the 'IDbContextTransaction'
- Added an endpoint in the ValuesController which is included in SQL Server, RabbitMQ sample named 'EntityFrameworkWithExistingTransaction'

#### Affected components:
- Sample.RabbitMQ.SqlServer.Controllers.ValuesController
- ICapTransaction.SqlServer

#### How to test:
I've included a sample in the SQL server, RabbitMQ sample which can be helpful in testing it, it's routed at '/ef/transaction/existing'

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines
