### PR TITLE
修复为kafka自定义参数时，某些参数无法被正确设置

### DIFF
--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -43,20 +43,9 @@ public class ConnectionPool : IConnectionPool, IDisposable
             BootstrapServers = _options.Servers,
         };
 
-        if (!_options.MainConfig.ContainsKey("queue.buffering.max.messages"))
-        {
-            config.QueueBufferingMaxMessages = 10;
-        }
-
-        if(!_options.MainConfig.ContainsKey("message.timeout.ms"))
-        {
-            config.MessageTimeoutMs = 5000;
-        }
-
-        if (!_options.MainConfig.ContainsKey("request.timeout.ms"))
-        {
-            config.RequestTimeoutMs = 3000;
-        }
+        config.QueueBufferingMaxMessages ??= 10;
+        config.MessageTimeoutMs ??= 5000;
+        config.RequestTimeoutMs ??= 3000;
 
         producer = BuildProducer(config);
 

--- a/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
+++ b/src/DotNetCore.CAP.Kafka/IConnectionPool.Default.cs
@@ -41,10 +41,22 @@ public class ConnectionPool : IConnectionPool, IDisposable
         var config = new ProducerConfig(new Dictionary<string, string>(_options.MainConfig))
         {
             BootstrapServers = _options.Servers,
-            QueueBufferingMaxMessages = 10,
-            MessageTimeoutMs = 5000,
-            RequestTimeoutMs = 3000
         };
+
+        if (!_options.MainConfig.ContainsKey("queue.buffering.max.messages"))
+        {
+            config.QueueBufferingMaxMessages = 10;
+        }
+
+        if(!_options.MainConfig.ContainsKey("message.timeout.ms"))
+        {
+            config.MessageTimeoutMs = 5000;
+        }
+
+        if (!_options.MainConfig.ContainsKey("request.timeout.ms"))
+        {
+            config.RequestTimeoutMs = 3000;
+        }
 
         producer = BuildProducer(config);
 


### PR DESCRIPTION
修复为kafka自定义参数时，某些参数无法被正确设置
无法设置的options: queue.buffering.max.messages, message.timeout.ms, request.timeout.ms
