### PR TITLE
Fix minor typos and tests

### DIFF
--- a/docs/content/about/release-notes.md
+++ b/docs/content/about/release-notes.md
@@ -49,7 +49,7 @@ Now CAP dashboard auth/authz mechanism to leverage the "ASP.NET Core" way of doi
 * Add `FallbackWindowLookbackSeconds` option to configure the retry processor to pick up the backtrack time window for Scheduled or Failed status messages. (#1455) Thanks @apatozi
 * Update IConsumerRegister.Default.cs to make dispose thread safe. (#1438) Thanks @blashbul
 * Compatible with .NET 8's dependency injection KeyedService. (#1436) Thanks @EashShow
-* Add virtual method to custom delay backtrack time window during delayed publishing large messges. (#1429) Thanks @PoteRii
+* Add virtual method to custom delay backtrack time window during delayed publishing large messages. (#1429) Thanks @PoteRii
 
 **Bug Fixed:**
 
@@ -624,7 +624,7 @@ db.CapReceivedMessage.update({},{"$set" : {"Version" : "1"}});
 **Bug Fixed:**
 
 - Fixed different groups of the same topic name in one instance will cause routing bug. (#235)
-- Fixed message presistence bug. (#240)
+- Fixed message persistence bug. (#240)
 - Fixed RabbitMQ topic name contains numbers will cause exception bug. (#181)
 
 ## Version 2.3.1 (2018-10-29)
@@ -659,7 +659,7 @@ If you have any migration question, please comment in issue (#190).
 
 **Bug Fixed:**
 
-- Fix message still sent if transaction faild bug. (#118)
+- Fix message still sent if transaction failed bug. (#118)
 - Multiple events in one transaction. (#171)
 
 ## Version 2.2.5 (2018-07-19)

--- a/src/DotNetCore.CAP/OperateResult.cs
+++ b/src/DotNetCore.CAP/OperateResult.cs
@@ -53,7 +53,7 @@ public struct OperateResult : IEqualityComparer<OperateResult>
 public record struct OperateError
 {
     /// <summary>
-    /// Gets or sets ths code for this error.
+    /// Gets or sets the code for this error.
     /// </summary>
     public string Code { get; set; }
 

--- a/test/DotNetCore.CAP.MySql.Test/MySqlStorageConnectionTest.cs
+++ b/test/DotNetCore.CAP.MySql.Test/MySqlStorageConnectionTest.cs
@@ -26,7 +26,7 @@ namespace DotNetCore.CAP.MySql.Test
         }
 
         [Fact]
-        public void StorageMessageTest()
+        public async Task StorageMessageTest()
         {
             var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
@@ -35,12 +35,12 @@ namespace DotNetCore.CAP.MySql.Test
             };
             var message = new Message(header, null);
 
-            var mdMessage = _storage.StoreMessageAsync("test.name", message);
+            var mdMessage = await _storage.StoreMessageAsync("test.name", message);
             Assert.NotNull(mdMessage);
         }
 
         [Fact]
-        public void StoreReceivedMessageTest()
+        public async Task StoreReceivedMessageTest()
         {
             var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
@@ -49,7 +49,7 @@ namespace DotNetCore.CAP.MySql.Test
             };
             var message = new Message(header, null);
 
-            var mdMessage = _storage.StoreReceivedMessageAsync("test.name", "test.group", message);
+            var mdMessage = await _storage.StoreReceivedMessageAsync("test.name", "test.group", message);
             Assert.NotNull(mdMessage);
         }
 
@@ -84,7 +84,7 @@ namespace DotNetCore.CAP.MySql.Test
             };
             var message = new Message(header, null);
 
-            var mdMessage = await _storage.StoreMessageAsync("test.name", message);
+            var mdMessage = await _storage.StoreReceivedMessageAsync("test.name", "test.group", message);
 
             await _storage.ChangeReceiveStateAsync(mdMessage, StatusName.Succeeded);
         }


### PR DESCRIPTION
## Summary
- fix typos in release notes
- correct documentation comment
- make MySql storage tests async and store received messages before state change

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684192a424b88320863385df4471c420