### PR TITLE
feat: Enhance SubscribeFilter to Support Multiple Instances

### DIFF
--- a/src/DotNetCore.CAP/CAP.Builder.cs
+++ b/src/DotNetCore.CAP/CAP.Builder.cs
@@ -101,7 +101,7 @@ public sealed class CapBuilder
     /// <typeparam name="T">Type of filter</typeparam>
     public CapBuilder AddSubscribeFilter<T>() where T : class, ISubscribeFilter
     {
-        Services.TryAddScoped<ISubscribeFilter, T>();
+        Services.AddScoped<ISubscribeFilter, T>();
         return this;
     }
 


### PR DESCRIPTION
 ###  Feature: Enhance SubscribeFilter to Support Multiple Instances

####  Summary
This PR enhances the filtering mechanism by allowing the use of multiple filters instead of just one. It provides more flexibility and enables advanced scenarios where multiple filters need to be applied in sequence or conditionally.

####  What Has Changed
- Modified the configuration model to support multiple filters.
- Preserved backward compatibility: single-filter configurations still work. 

####  Why It's Useful
This feature enables scenarios where users need to:
- Apply layered processing logic
- Compose filters in different modules
- Have more granular control over message handling

####  Testing
- [x] All existing tests pass

####  Notes
- This is my first contribution to CAP. 
- Let me know if you'd like any changes, improvements, or if you'd prefer an issue to be created for tracking.

#### Additional Request
Hello, thank you for your efforts on the CAP project. This PR is ready for review to support multiple filter instances, and the tests have passed successfully. Is there any change or additional information needed? @yang-xiaodong
