### PR TITLE
Fix the connection error of the RabbitMQ cluster when SSL is enabled.

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
@@ -109,8 +109,12 @@ public class ConnectionChannelPool : IConnectionChannelPool, IDisposable
         if (options.HostName.Contains(","))
         {
             options.ConnectionFactoryOptions?.Invoke(factory);
-
-            return () => factory.CreateConnectionAsync(AmqpTcpEndpoint.ParseMultiple(options.HostName));
+            var endpoints = AmqpTcpEndpoint.ParseMultiple(options.HostName);
+            foreach (var endpoint in endpoints)
+            {
+                endpoint.Ssl = factory.Ssl;
+            }
+            return () => factory.CreateConnectionAsync(endpoints);
         }
 
         factory.HostName = options.HostName;


### PR DESCRIPTION
### Description:
Fix the connection error of the RabbitMQ cluster when SSL is enabled.

#### Issue(s) addressed:
- https://github.com/dotnetcore/CAP/issues/1733

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines