### PR TITLE
Remove invalid syntax from delete statements

### DIFF
--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -234,7 +234,7 @@ public class PostgreSqlDataStorage : IDataStorage
 
     public async Task<int> DeleteReceivedMessageAsync(long id)
     {
-        var sql = $@"DELETE FROM {_recName} WHERE ""Id""={id} FOR DELETE SKIP LOCKED";
+        var sql = $@"DELETE FROM {_recName} WHERE ""Id""={id}";
 
         var connection = _options.Value.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);
@@ -244,7 +244,7 @@ public class PostgreSqlDataStorage : IDataStorage
 
     public async Task<int> DeletePublishedMessageAsync(long id)
     {
-        var sql = $@"DELETE FROM {_pubName} WHERE ""Id""={id} FOR DELETE SKIP LOCKED";
+        var sql = $@"DELETE FROM {_pubName} WHERE ""Id""={id}";
 
         var connection = _options.Value.CreateConnection();
         await using var _ = connection.ConfigureAwait(false);


### PR DESCRIPTION
### Description:
Remove invalid syntax from delete statements for the PostgreSQL provider.

#### Issue(s) addressed:
- Fixes #1736 

#### Changes:
- _List the major changes made in this PR, preferably in bullet points._

#### Affected components:
- DotNetCore.CAP.DashBoard
- DotNetCore.CAP.PostgreSql

#### How to test:
Select a record from received or published in the dashboard and try to delete it while using the PostgreSql database provider.


### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ ] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong 
