### PR TITLE
Honor allow.auto.create.topics for Kafka

### DIFF
--- a/docs/content/user-guide/en/transport/kafka.md
+++ b/docs/content/user-guide/en/transport/kafka.md
@@ -64,6 +64,18 @@ services.AddCap(capOptions =>
 
 [https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
 
+To prevent CAP from creating topics automatically, disable topic auto creation:
+
+```csharp
+services.AddCap(capOptions =>
+{
+    capOptions.UseKafka(kafkaOption =>
+    {
+        kafkaOption.MainConfig.Add("allow.auto.create.topics", "false");
+    });
+});
+```
+
 #### CustomHeadersBuilder Options
 
 When the message sent from a heterogeneous system, because of the CAP needs to define additional headers, so an exception will occur at this time. By providing this parameter to set the custom headersn to make the subscriber works.

--- a/docs/content/user-guide/zh/transport/kafka.md
+++ b/docs/content/user-guide/zh/transport/kafka.md
@@ -65,6 +65,18 @@ MainConfig 为配置字典，你可以通过以下链接找到其支持的配置
 
 [https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
 
+要禁止 CAP 自动创建主题，可以关闭该功能：
+
+```csharp
+services.AddCap(capOptions =>
+{
+    capOptions.UseKafka(kafkaOption =>
+    {
+        kafkaOption.MainConfig.Add("allow.auto.create.topics", "false");
+    });
+});
+```
+
 #### CustomHeadersBuilder Options
 
 有关 `CustomHeadersBuilder` 的说明：


### PR DESCRIPTION
## Summary
- respect allow.auto.create.topics and skip topic creation when disabled
- document how to turn off Kafka topic auto-creation

## Testing
- `dotnet test` *(fails: DotNetCore.CAP.MySql.Test.*)*

------

Issue: #1738