### PR TITLE
Enable Parallel Sending of Delayed Messages

### DIFF
--- a/test/DotNetCore.CAP.Test/DispatcherTests.cs
+++ b/test/DotNetCore.CAP.Test/DispatcherTests.cs
@@ -161,7 +161,77 @@ public class DispatcherTests
         // Assert
         sender.ReceivedMessages.Select(m => m.DbId).Should().Equal(["3", "2", "1"]);
     }
-    
+
+    [Fact]
+    public async Task EnqueueToScheduler_ShouldBeThreadSafe_WhenDelayLessThenMinuteAndParallelSendEnabled()
+    {
+        // Arrange
+        var sender = new TestThreadSafeMessageSender();
+        var options = Options.Create(new CapOptions
+        {
+            EnableSubscriberParallelExecute = true,
+            EnablePublishParallelSend = true,
+            SubscriberParallelExecuteThreadCount = 2,
+            SubscriberParallelExecuteBufferFactor = 2
+        });
+        var dispatcher = new Dispatcher(_logger, sender, options, _executor, _storage);
+
+        using var cts = new CancellationTokenSource();
+        var messages = Enumerable.Range(1, 10000)
+            .Select(i => CreateTestMessage(i.ToString()))
+            .ToArray();
+
+        // Act
+        await dispatcher.Start(cts.Token);
+        var dateTime = DateTime.Now.AddSeconds(1);
+        await Parallel.ForEachAsync(messages, CancellationToken.None,
+            async (m, ct) => { await dispatcher.EnqueueToScheduler(m, dateTime); });
+
+        await Task.Delay(1500, CancellationToken.None);
+
+        await cts.CancelAsync();
+
+        // Assert
+        sender.Count.Should().Be(10000);
+
+        var receivedMessages = sender.ReceivedMessages.Select(m => m.DbId).Order().ToList();
+        var expected = messages.Select(m => m.DbId).Order().ToList();
+        expected.Should().Equal(receivedMessages);
+    }
+
+    [Fact]
+    public async Task EnqueueToScheduler_ShouldSendMessagesInCorrectOrder_WhenParallelSendEnabled()
+    {
+        // Arrange
+        var sender = new TestThreadSafeMessageSender();
+        var options = Options.Create(new CapOptions
+        {
+            EnableSubscriberParallelExecute = true,
+            EnablePublishParallelSend = true,
+            SubscriberParallelExecuteThreadCount = 2,
+            SubscriberParallelExecuteBufferFactor = 2,
+        });
+        var dispatcher = new Dispatcher(_logger, sender, options, _executor, _storage);
+
+        using var cts = new CancellationTokenSource();
+        var messages = Enumerable.Range(1, 3)
+            .Select(i => CreateTestMessage(i.ToString()))
+            .ToArray();
+
+        // Act
+        await dispatcher.Start(cts.Token);
+        var dateTime = DateTime.Now;
+
+        await dispatcher.EnqueueToScheduler(messages[0], dateTime.AddSeconds(1));
+        await dispatcher.EnqueueToScheduler(messages[1], dateTime.AddMilliseconds(200));
+        await dispatcher.EnqueueToScheduler(messages[2], dateTime.AddMilliseconds(100));
+
+        await Task.Delay(1200, CancellationToken.None);
+        await cts.CancelAsync();
+
+        // Assert
+        sender.ReceivedMessages.Select(m => m.DbId).Should().Equal(["3", "2", "1"]);
+    }
 
     private MediumMessage CreateTestMessage(string id = "1")
     {


### PR DESCRIPTION
### Description:
If `EnableParallelSend` is `true`, then delayed messages will be sent in parallel too. Instead of sending them immediately, they first placed at the `_publishedChannel` like the regular messages. 

#### Issue(s) addressed:
- #1752 

#### Changes:
- Publish delayed messages to the `_publishedChannel` if `_enableParallelSend = true`.

#### Affected components:
- `Dispatcher` from the `IDispatcher.Default.cs` file.

#### How to test:
Turn on `EnableParallelSend` and use `PublishDelayAsync` or `PublishDelay` methods.

### Checklist:
- [X] I have tested my changes locally
- [X] I have updated tests of `Dispatcher`.
- [X] My changes follow the project's code style guidelines

### Reviewers:
I'm new to this project, so anybody who knows this part of the code :)