### PR TITLE
Fix #1774 : Implement ListServices method in ConsulNodeDiscoveryProvider

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/NodeDiscovery/INodeDiscoveryProvider.Consul.cs
+++ b/src/DotNetCore.CAP.Dashboard/NodeDiscovery/INodeDiscoveryProvider.Consul.cs
@@ -147,4 +147,11 @@ public class ConsulNodeDiscoveryProvider : INodeDiscoveryProvider
                 $"Get consul nodes raised an exception. Exception:{ex.Message},{ex.InnerException.Message}");
         }
     }
+
+    public async Task<IList<Node>> ListServices(string ns = null)
+    {
+        // For Consul, namespace is not directly supported, so we return all CAP services
+        // This is similar to GetNodes but provides a consistent interface
+        return await GetNodes(ns, CancellationToken.None);
+    }
 }


### PR DESCRIPTION
… service listing

Implemented a new asynchronous method, ListServices, in the ConsulNodeDiscoveryProvider class. This method returns all CAP services, providing a consistent interface similar to GetNodes, while addressing the lack of direct namespace support in Consul.

### Description:
This PR fixes the missing implementation of the `ListServices` method in the `ConsulNodeDiscoveryProvider` class. When the Dashboard route `/api/list-svc/{namespace}` was called, it would throw a `NotImplementedException` because `ConsulNodeDiscoveryProvider` did not implement the `ListServices` method, resulting in a 404 error response.

By implementing the `ListServices` method, the Consul node discovery provider can now correctly return a list of services, maintaining consistent behavior with the Kubernetes node discovery provider.

#### Issue(s) addressed:
- Fixed `NotImplementedException` caused by missing `ListServices` implementation in `ConsulNodeDiscoveryProvider`
- Fixed 404 error returned by Dashboard API endpoint `/api/list-svc/{namespace}`

#### Changes:
- Implemented `ListServices(string ns = null)` method in the `ConsulNodeDiscoveryProvider` class
- The `ListServices` method internally calls the existing `GetNodes` method to retrieve all CAP services
- Since Consul does not directly support namespace concepts, the `ns` parameter is passed but not used (consistent with the existing behavior of `GetNodes`)

#### Affected components:
- `src/DotNetCore.CAP.Dashboard/NodeDiscovery/INodeDiscoveryProvider.Consul.cs` - Added `ListServices` method implementation
- Dashboard API route `/api/list-svc/{namespace}` - Now functions correctly

#### How to test:
1. Ensure the project is configured to use Consul as the node discovery provider
2. Start the application and ensure the Consul service is running
3. Access the Dashboard API endpoint using a browser or HTTP client: `GET /cap/api/list-svc/{namespace}`
   - Replace `{namespace}` with any value (since Consul doesn't use namespaces)
4. Verify the response:
   - Should return 200 status code
   - Response body should contain a list of CAP service nodes (JSON format)
   - Should no longer throw `NotImplementedException` or return 404 errors
5. Optional: Compare behavior with the Kubernetes node discovery provider to ensure consistency

### Additional notes (optional):
- This implementation maintains interface consistency with the `ListServices` method in `K8sNodeDiscoveryProvider`
- Consul has limited namespace support, so the `ns` parameter is not used in the current implementation, but is retained for interface compatibility
- If namespace functionality is needed for Consul in the future, filtering logic can be added to this method

### Checklist:
- [x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- _Suggest review by team members familiar with Dashboard and node discovery mechanisms_