### PR TITLE
Add missing headers fallback for non-CAP message producers in KafkaConsumerClient

### DIFF
--- a/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
+++ b/src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs
@@ -190,6 +190,20 @@ public class KafkaConsumerClient : IConsumerClient
             headers[header.Key] = val != null ? Encoding.UTF8.GetString(val) : null;
         }
 
+        // Ensure required headers exist for compatibility with non-CAP message producers.
+        // If the message is produced by a non-CAP component, these headers may be missing,
+        // but they are required by the CAP consumer for proper message processing.
+        if (!headers.ContainsKey(Headers.MessageId))
+        {
+            headers.Add(Headers.MessageId, "");
+        }
+
+        if (!headers.ContainsKey(Headers.MessageName))
+        {
+            // Use the Kafka topic as the message name if not provided in headers.
+            headers.Add(Headers.MessageName, consumerResult.Topic);
+        }
+
         headers[Headers.Group] = _groupId;
 
         if (_kafkaOptions.CustomHeadersBuilder != null)


### PR DESCRIPTION
# Add missing headers fallback for non-CAP message producers in KafkaConsumerClient

### Description:
This PR adds compatibility support for messages produced by non-CAP components in the Kafka consumer client. When consuming messages from Kafka, the CAP framework requires certain headers (`cap-msg-id` and `cap-msg-name`) to be present for proper message processing. However, messages produced by external systems or non-CAP components may not include these headers, which can cause processing failures.

The changes ensure that if these required headers are missing, default values are provided:
- `cap-msg-id`: An empty string is added if missing
- `cap-msg-name`: The Kafka topic name is used as a fallback if missing

This enhancement allows CAP to consume and process messages from heterogeneous systems without requiring modifications to the message producers, improving interoperability and integration capabilities.

#### Issue(s) addressed:
- Improves compatibility with non-CAP message producers
- Prevents processing failures when required headers are missing

#### Changes:
- Added header validation and fallback logic in `KafkaConsumerClient.ConsumeAsync()` method
- Added check for `Headers.MessageId` and provide empty string as default if missing
- Added check for `Headers.MessageName` and use Kafka topic name as fallback if missing
- Added comprehensive English comments explaining the compatibility requirements

#### Affected components:
- `src/DotNetCore.CAP.Kafka/KafkaConsumerClient.cs` - Modified the `ConsumeAsync` method to add missing headers fallback

#### How to test:
1. **Test with CAP-produced messages (existing behavior):**
   - Publish a message using CAP's `ICapPublisher`
   - Verify that the message is consumed and processed correctly
   - Confirm that existing headers are preserved and not overwritten

2. **Test with non-CAP-produced messages (new behavior):**
   - Produce a message to Kafka topic without `cap-msg-id` and `cap-msg-name` headers
   - Use a Kafka producer (e.g., from Java, Python, or other languages) to send a message without CAP headers
   - Verify that the CAP consumer can successfully consume and process the message
   - Confirm that:
     - `cap-msg-id` header is added with empty string value
     - `cap-msg-name` header is added with the Kafka topic name
     - Message processing completes without errors

3. **Test with partial headers:**
   - Send a message with only `cap-msg-id` but missing `cap-msg-name`
   - Send a message with only `cap-msg-name` but missing `cap-msg-id`
   - Verify that missing headers are properly filled with defaults

4. **Integration test:**
   - Set up a test environment with Kafka
   - Use a non-CAP producer to send messages to a Kafka topic
   - Configure CAP to consume from that topic
   - Verify end-to-end message processing works correctly

### Additional notes (optional):
- This change maintains backward compatibility with existing CAP-produced messages
- The fallback values are chosen to ensure minimal disruption:
  - Empty string for MessageId allows the system to generate one if needed
  - Topic name for MessageName provides a meaningful default that matches the message routing
- Similar compatibility enhancements could be considered for other transport providers (RabbitMQ, Azure Service Bus, etc.) if needed

### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (comments in code)
- [ ] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
- Please review the compatibility approach and verify that the fallback values are appropriate
- Consider if similar changes should be applied to other transport providers for consistency

