### PR TITLE
Adding option to add sessionid to with custom producers

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/ITransport.AzureServiceBus.cs
@@ -68,7 +68,7 @@ internal class AzureServiceBusTransport : ITransport, IServiceBusProducerDescrip
                 CorrelationId = transportMessage.GetCorrelationId()
             };
 
-            if (_asbOptions.Value.EnableSessions)
+            if (_asbOptions.Value.EnableSessions || producer.EnableSessions)
             {
                 transportMessage.Headers.TryGetValue(AzureServiceBusHeaders.SessionId, out var sessionId);
                 message.SessionId = string.IsNullOrEmpty(sessionId) ? transportMessage.GetId() : sessionId;

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/IServiceBusProducerDescriptor.cs
@@ -10,33 +10,37 @@ public interface IServiceBusProducerDescriptor
     string TopicPath { get; }
     string MessageTypeName { get; }
     bool CreateSubscription { get; }
+    bool EnableSessions { get; }
 }
 
 public class ServiceBusProducerDescriptor : IServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptor(Type type, string topicPath, bool createSubscription = true)
+    public ServiceBusProducerDescriptor(Type type, string topicPath, bool createSubscription = true, bool enableSessions = false)
     {
         MessageTypeName = type.Name;
         TopicPath = topicPath;
         CreateSubscription = createSubscription;
+        EnableSessions = enableSessions;
     }
 
-    public ServiceBusProducerDescriptor(string typeName, string topicPath, bool createSubscription = true)
+    public ServiceBusProducerDescriptor(string typeName, string topicPath, bool createSubscription = true, bool enableSessions = false)
     {
         MessageTypeName = typeName;
         TopicPath = topicPath;
         CreateSubscription = createSubscription;
+        EnableSessions = enableSessions;
     }
 
     public string TopicPath { get; set; }
 
     public string MessageTypeName { get; }
     public bool CreateSubscription { get; internal set; }
+    public bool EnableSessions { get; internal set; }
 }
 
 public class ServiceBusProducerDescriptor<T> : ServiceBusProducerDescriptor
 {
-    public ServiceBusProducerDescriptor(string topicPath, bool createSubscription = true) : base(typeof(T), topicPath, createSubscription)
+    public ServiceBusProducerDescriptor(string topicPath, bool createSubscription = true, bool enableSessions = false) : base(typeof(T), topicPath, createSubscription, enableSessions)
     {
     }
 }

--- a/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/Producer/ServiceBusProducerDescriptorBuilder.cs
@@ -9,6 +9,7 @@ public class ServiceBusProducerDescriptorBuilder<T>
 {
     private string TopicPath { get; set; } = null!;
     private bool CreateSubscription { get; set; }
+    private bool EnableSessions { get; set; }
 
     public ServiceBusProducerDescriptorBuilder<T> UseTopic(string topicPath)
     {
@@ -22,8 +23,14 @@ public class ServiceBusProducerDescriptorBuilder<T>
         return this;
     }
 
+    public ServiceBusProducerDescriptorBuilder<T> WithSessions()
+    {
+        EnableSessions = true;
+        return this;
+    }
+
     public ServiceBusProducerDescriptor<T> Build()
     {
-        return new ServiceBusProducerDescriptor<T>(TopicPath, CreateSubscription);
+        return new ServiceBusProducerDescriptor<T>(TopicPath, CreateSubscription, EnableSessions);
     }
 }


### PR DESCRIPTION
### Description:
As of right now, the session configuration is global, meaning when the session is enabled, both producer and consumer must work in session mode. This change makes it possible to keep the consumer non-sessioned and have the producer to produce session-aware messages.

#### Changes:
- Updated AzureServiceBusTransport to set sessionid when custom producer has enabled sessions
- Updated ServiceBusProducerDescriptor with new EnableSession option

#### Affected components:
- AzureServiceBusTransport
- IServiceBusProducerDescriptor

#### How to test:
```bash
dotnet new console -o MyConsoleApp
dotnet add package Microsoft.Extensions.DependencyInjection
dotnet add package Microsoft.Extensions.Logging
dotnet add package Microsoft.Extensions.Logging.Console
dotnet add package Azure.Identity

dotnet reference add ..\src\DotNetCore.CAP.InMemoryStorage\DotNetCore.CAP.InMemoryStorage.csproj --project MyConsoleApp.csproj
dotnet reference add ..\src\DotNetCore.CAP.AzureServiceBus\DotNetCore.CAP.AzureServiceBus.csproj --project MyConsoleApp.csproj
dotnet reference add ..\src\DotNetCore.CAP\DotNetCore.CAP.csproj --project MyConsoleApp.csproj
```
```c#
using Azure.Identity;
using DotNetCore.CAP;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Logging;


string topicPath = "test-base-local-topic";
string customProducerTopicPath = "test-producer-local-topic";
string serviceBusNamespace = "my-namespace";

var services = new ServiceCollection().AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));

services
    .AddCap(
        cap =>
        {
            cap.UseStorageLock = true;
            cap.FailedRetryCount = 10;

            cap.UseInMemoryStorage();

            cap.UseAzureServiceBus(
                bus =>
                {
                    bus.TopicPath = topicPath;
                    bus.Namespace = serviceBusNamespace;
                    bus.TokenCredential = new DefaultAzureCredential();

                    bus.ConfigureCustomProducer<TestMessage>(c => c.UseTopic(customProducerTopicPath).WithSessions());
                });
        });

var serviceProvider = services
    .BuildServiceProvider();

var bootstrapper = serviceProvider.GetRequiredService<IBootstrapper>();
await bootstrapper.BootstrapAsync();
var cap = serviceProvider.GetRequiredService<ICapPublisher>();

var message = new TestMessage("Hello World!");
await cap.PublishAsync(nameof(TestMessage), message);

await Task.Delay(1000);
public record TestMessage(string Content);
```

### Additional notes (optional):
<img width="1390" height="839" alt="image" src="https://github.com/user-attachments/assets/2407a203-3fd0-4349-8451-c62fbca89c8a" />


### Checklist:
- [x] I have tested my changes locally
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the relevant tests (if applicable)
- [x] My changes follow the project's code style guidelines

### Reviewers:
@yang-xiaodong 
