### PR TITLE
Optimize transaction cleanup to prevent memory leaks

### DIFF
--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -46,6 +46,12 @@ internal class CapPublisher : ICapPublisher
         get => _asyncLocal.Value?.Transaction;
         set
         {
+            if (value == null)
+            {
+                // Clear the CapTransactionHolder held in the ExecutionContext to avoid long-term reference retention.
+                _asyncLocal.Value = null;
+                return;
+            }
             _asyncLocal.Value ??= new CapTransactionHolder();
             _asyncLocal.Value.Transaction = value;
         }
@@ -183,6 +189,11 @@ internal class CapPublisher : ICapPublisher
             TracingError(tracingTimestamp, message, e);
 
             throw;
+        }
+        finally 
+        {
+            // Whether successful or exceptional, explicitly clear the transaction reference in the current context after the release is completed.
+            Transaction = null; 
         }
     }
 


### PR DESCRIPTION
Enhanced the setter of the Transaction property in CapPublisher: when the property is assigned a null value, _asyncLocal.Value is cleared to avoid memory leaks caused by ExecutionContext holding a reference to CapTransactionHolder. Additionally, Transaction = null was added to the finally block of the method to ensure timely release of transactions.

### Description:
_Provide a more detailed description of the changes made in this PR. Explain the reason behind the changes and their expected impact on the project._

#### Issue(s) addressed:
- [Link to the related issue(s), if any]

#### Changes:
- _List the major changes made in this PR, preferably in bullet points._

#### Affected components:
- _List the components of the project that are affected by this PR._

#### How to test:
_Provide a step-by-step guide on how to test your changes. Include any relevant information like environment setup, dependencies, etc._

### Additional notes (optional):
_Provide any additional notes or context that may be relevant to the changes._

### Checklist:
- [ ] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ ] My changes follow the project's code style guidelines

### Reviewers:
- _Mention any reviewers you would like to review your PR. This can be helpful if you know someone who is familiar with the part of the codebase you're working on._
