### PR TITLE
fix: handle null Messages in AmazonSQS ReceiveMessageResponse

### DIFF
--- a/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
+++ b/src/DotNetCore.CAP.AmazonSQS/AmazonSQSConsumerClient.cs
@@ -90,7 +90,7 @@ internal sealed class AmazonSQSConsumerClient : IConsumerClient
         {
             var response = _sqsClient!.ReceiveMessageAsync(request, cancellationToken).GetAwaiter().GetResult();
 
-            if (response.Messages.Count == 1)
+            if (response?.Messages?.Count == 1)
             {
                 if (_groupConcurrent > 0)
                 {


### PR DESCRIPTION
### Description:
When Amazon SQS returns an empty queue response, the Messages property can be null instead of an empty list. The Listening method accessed response.Messages.Count without null checking, causing a NullReferenceException that permanently killed the consumer thread.
#### Issue(s) addressed:

No related issue (discovered during local testing)

#### Changes:

Added null-conditional operators in AmazonSQSConsumerClient.Listening to safely handle null Messages property in SQS response

#### Affected components:

DotNetCore.CAP.AmazonSQS

#### How to test:

Configure CAP with UseAmazonSQS pointing to a real AWS SQS queue
Start the application with an empty queue
Without the fix: NullReferenceException is thrown after the first polling attempt and the consumer dies permanently
With the fix: polling continues every 5 seconds without errors

### Additional notes:
The AWS SQS SDK returns Messages = null instead of an empty list when no messages are available. This behavior causes the consumer thread to crash on the first empty poll, making retry functionality completely broken until service restart.
### Checklist:

✔️ I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)

✔️ My changes follow the project's code style guidelines

### Reviewers:

@yang-xiaodong 