### PR TITLE
fix(dashboard): avoid /list-svc call when namespaces are unavailable

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/wwwroot/src/pages/Nodes.vue
+++ b/src/DotNetCore.CAP.Dashboard/wwwroot/src/pages/Nodes.vue
@@ -136,14 +136,15 @@ export default {
       axios.get('/list-ns').then(res => {
         if (res.data.length > 0) {
           this.nsList = res.data;
+          var ns = this.getCookie("cap.node.ns");
+          if (ns) {
+            this.selected = ns;
+            this.fetchSvcs();
+          }
         }
+      }).finally(() => {
+        this.isBusy = false;
       });
-      this.isBusy = false;
-      var ns = this.getCookie("cap.node.ns");
-      if (ns) {
-        this.selected = ns;
-        this.fetchSvcs();
-      }
     },
 
     fetchSvcs() {


### PR DESCRIPTION
### Motivation
- Prevent the dashboard from invoking `/list-svc/{namespace}` when namespace discovery returns empty (for example in Consul mode), which could trigger unnecessary or incorrect requests and produce UI state inconsistencies.

### Description
- Gate reading `cap.node.ns` and calling `fetchSvcs()` behind a non-empty `/list-ns` response and move `isBusy = false` into the request `.finally()` so loading state is cleared after the namespace call completes; change is in `src/DotNetCore.CAP.Dashboard/wwwroot/src/pages/Nodes.vue`.

### Testing
- Lightweight repository checks were run (`git status`, `git diff`, `git commit`) and the updated file was inspected with `nl` to verify the change; these commands succeeded and no unit/integration tests were executed.

------

Fixes #1774 